### PR TITLE
ci(github): no longer scan licenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
         uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         with:
           image-ref: ${{ env.IMAGE_TAG }}
-          scanners: vuln,secret,license
           format: sarif
           output: results.sarif
 


### PR DESCRIPTION
Because analysis is trivial since we just rely on Ubuntu and PaperMC mainly. Additionally, generating hundreds of reports is not sustainable regarding maintenance effort.