### PR TITLE
feat: include standard OCI annotations on published images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,5 +88,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ROOT_PROJECT_DIR: ${{ github.workspace }}
+          REVISION: ${{ github.sha }}
         working-directory: .github/semantic-release/
         run: npx --no-install semantic-release

--- a/src/main/docker-bake.hcl
+++ b/src/main/docker-bake.hcl
@@ -8,6 +8,9 @@ variable "IMAGE_NAME" {
   # TODO: make organization configurable
   default = "djaytan/papermc-server"
 }
+variable "REVISION" {
+  default = ""
+}
 
 # Tags properties
 variable "IS_LATEST_RELEASE" {
@@ -72,6 +75,17 @@ target "release" {
     tag("${MINECRAFT_VERSION}-v${extractMajorMinorFromSemVer(IMAGE_VERSION)}"),
     tag("${MINECRAFT_VERSION}-v${extractMajorFromSemVer(IMAGE_VERSION)}")
   ]
-  # TODO: annotations => https://github.com/opencontainers/image-spec/blob/main/annotations.md (or at Dockerfile level maybe?)
-  # TODO: what about labels?
+  annotations = [
+    "org.opencontainers.image.title=PaperMC Server",
+    "org.opencontainers.image.description=Dockerized and fine-grained customizable PaperMC server.",
+    "org.opencontainers.image.version=${MINECRAFT_VERSION}-v${IMAGE_VERSION}-${date()}",
+    "org.opencontainers.image.url=https://github.com/Djaytan/docker-papermc-server",
+    "org.opencontainers.image.documentation=https://github.com/Djaytan/docker-papermc-server",
+    "org.opencontainers.image.source=https://github.com/Djaytan/docker-papermc-server.git",
+    "org.opencontainers.image.authors=Djaytan <https://github.com/Djaytan>",
+    "org.opencontainers.image.vendor=Djaytan",
+    "org.opencontainers.image.licenses=GPL-3.0-or-later",
+    "org.opencontainers.image.created=${formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timestamp())}",
+    "${notequal(REVISION, "") ? "org.opencontainers.image.revision=${REVISION}" : ""}"
+  ]
 }

--- a/src/test/localdev.sh
+++ b/src/test/localdev.sh
@@ -7,6 +7,5 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 bash "$SCRIPT_DIR"/build-dev.sh
 
 echo '▶️ Starting the localdev PaperMC server...'
-# TODO: migrate to Docker compose?
 docker run --rm -it -p 25565:25565/tcp -p 25565:25565/udp -e EULA=true 'djaytan/papermc-server:dev'
 echo '🛑 The localdev PaperMC server has been stopped and removed.'


### PR DESCRIPTION
For example:

```
"org.opencontainers.image.title=PaperMC Server",
"org.opencontainers.image.description=Dockerized and fine-grained customizable PaperMC server.",
"org.opencontainers.image.version=1.21.4-v1.0.0-20250407",
"org.opencontainers.image.url=https://github.com/Djaytan/docker-papermc-server",
"org.opencontainers.image.documentation=https://github.com/Djaytan/docker-papermc-server",
"org.opencontainers.image.source=https://github.com/Djaytan/docker-papermc-server.git",
"org.opencontainers.image.authors=Djaytan \u003chttps://github.com/Djaytan\u003e",
"org.opencontainers.image.vendor=Djaytan",
"org.opencontainers.image.licenses=GPL-3.0-or-later",
"org.opencontainers.image.created=2025-04-07T21:41:44Z",
"org.opencontainers.image.revision=e0f3d523b9c670409e04225b737a838f0391d8b7"
```