### PR TITLE
ci: leverage GitHub Actions caches in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
           workdir: src/main/
           targets: dev
           load: true # Required for tests in later steps
+          set: |
+            *.cache-from=type=gha,timeout=20s
+            *.cache-to=type=gha,mode=max,timeout=20s
 
       - name: Test
         run: src/test/test.sh

--- a/src/main/Dockerfile
+++ b/src/main/Dockerfile
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+# TODO: what about an alpine variant?
 FROM docker.io/ubuntu:noble@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS build
 
 ARG MINECRAFT_VERSION
@@ -64,11 +65,11 @@ USER papermc
 
 WORKDIR /home/papermc
 
-# Copy the PaperMC server
-COPY --from=build --chown=papermc --chmod=500 /build/papermc-server-*.jar ./
-
 # Copy license file
 ADD --chmod=444 https://raw.githubusercontent.com/Djaytan/docker-papermc-server/refs/heads/main/LICENSE.md .
+
+# Copy the PaperMC server
+COPY --from=build --chown=papermc --chmod=500 /build/papermc-server-*.jar ./
 
 # Copy the configuration files
 # Write access is required by PaperMC to update the configuration files


### PR DESCRIPTION
cf. https://docs.docker.com/build/ci/github-actions/cache/

Example outcome: https://github.com/Djaytan/docker-papermc-server/actions/runs/14345358649/attempts/2#summary-40214175832

![image](https://github.com/user-attachments/assets/4b66c807-3f54-494c-b546-710e3ace86ae)