### PR TITLE
feat: publish OCI images with annotations at index level too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 
 permissions: {}
 
+# TODO: explore more options: https://docs.docker.com/build/ci/github-actions/
+# TODO: explore more options: https://github.com/docker/build-push-action
 # TODO: Experiment GitHub deployments
 # TODO: do we want to test multi-arch build?
 # TODO: reproductible builds? https://docs.docker.com/build/ci/github-actions/reproducible-builds/
@@ -76,7 +78,7 @@ jobs:
           source: .
           workdir: src/main/
           targets: dev
-          load: true # Required for tests in later steps
+          load: true # Export to Docker - Required for tests in later steps
           set: |
             *.cache-from=type=gha,timeout=20s
             *.cache-to=type=gha,mode=max,timeout=20s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 
+# TODO: actually doesn't work if semver not incremented. Better to make a separated workflow for this?
 on:
   workflow_dispatch:
   push:
@@ -102,6 +103,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      # TODO: Set annotation level to manifest,index: https://docs.docker.com/build/ci/github-actions/annotations/#configure-annotation-level
       - name: Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/src/main/Dockerfile
+++ b/src/main/Dockerfile
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+# TODO: move to src/main/docker instead
 # TODO: what about an alpine variant?
 FROM docker.io/ubuntu:noble@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS build
 

--- a/src/main/docker-bake.hcl
+++ b/src/main/docker-bake.hcl
@@ -31,6 +31,11 @@ function "tag" {
   result = "${notequal(REGISTRY, "") ? "${REGISTRY}/" : ""}${IMAGE_NAME}:${tag}"
 }
 
+function "annotation" {
+  params = [key, value]
+  result = "index,manifest:${key}=${value}"
+}
+
 function "extractMajorFromSemVer" {
   params = [semver]
   result = split(".", semver)[0]
@@ -76,16 +81,16 @@ target "release" {
     tag("${MINECRAFT_VERSION}-v${extractMajorFromSemVer(IMAGE_VERSION)}")
   ]
   annotations = [
-    "org.opencontainers.image.title=PaperMC Server",
-    "org.opencontainers.image.description=Dockerized and fine-grained customizable PaperMC server.",
-    "org.opencontainers.image.version=${MINECRAFT_VERSION}-v${IMAGE_VERSION}-${date()}",
-    "org.opencontainers.image.url=https://github.com/Djaytan/docker-papermc-server",
-    "org.opencontainers.image.documentation=https://github.com/Djaytan/docker-papermc-server",
-    "org.opencontainers.image.source=https://github.com/Djaytan/docker-papermc-server.git",
-    "org.opencontainers.image.authors=Djaytan <https://github.com/Djaytan>",
-    "org.opencontainers.image.vendor=Djaytan",
-    "org.opencontainers.image.licenses=GPL-3.0-or-later",
-    "org.opencontainers.image.created=${formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timestamp())}",
-    "${notequal(REVISION, "") ? "org.opencontainers.image.revision=${REVISION}" : ""}"
+    annotation("org.opencontainers.image.title", "PaperMC Server"),
+    annotation("org.opencontainers.image.description", "Dockerized and fine-grained customizable PaperMC server."),
+    annotation("org.opencontainers.image.version", "${MINECRAFT_VERSION}-v${IMAGE_VERSION}-${date()}"),
+    annotation("org.opencontainers.image.url", "https://github.com/Djaytan/docker-papermc-server"),
+    annotation("org.opencontainers.image.documentation", "https://github.com/Djaytan/docker-papermc-server"),
+    annotation("org.opencontainers.image.source", "https://github.com/Djaytan/docker-papermc-server.git"),
+    annotation("org.opencontainers.image.authors", "Djaytan <https://github.com/Djaytan>"),
+    annotation("org.opencontainers.image.vendor", "Djaytan"),
+    annotation("org.opencontainers.image.licenses", "GPL-3.0-or-later"),
+    annotation("org.opencontainers.image.created", "${formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timestamp())}"),
+    notequal(REVISION, "") ? annotation("org.opencontainers.image.revision", REVISION) : ""
   ]
 }


### PR DESCRIPTION
By default, annotations were published only at manifest level: https://docs.docker.com/build/metadata/annotations/#specify-annotation-level

Recommendation is to publish them at index level too when publishing multi-platform OCI images like it is the case for this project.