### PR TITLE
fix: no longer lock root user since useless

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -73,10 +73,6 @@ RUN apk add --no-cache bash gettext libudev-zero
 # BusyBox "adduser" doc: https://busybox.net/downloads/BusyBox.html#adduser
 RUN addgroup -S papermc && adduser -S -G papermc -h /home/papermc -s /sbin/nologin papermc
 
-# Lock root user for security purposes
-# TODO: remove since unecessary
-RUN passwd -l root
-
 # Now rely exclusively on the PaperMC user (rootless mode)
 USER papermc
 


### PR DESCRIPTION
Not relevant when following best practices related to running containers (disabling root access, using Podman, Kubernetes security context, ...).