### PR TITLE
test: limit system resources to comply with OWASP rule #7

### DIFF
--- a/src/main/docker/runtime/start.sh
+++ b/src/main/docker/runtime/start.sh
@@ -70,4 +70,5 @@ echo 'File eula.txt processed'
 
 echo 'PaperMC server ready to start!'
 
+# TODO: ensure that the server replace PID 1 instead of spawning a child process (exec command)
 java $JVM_ARGUMENTS -jar "${SCRIPT_DIR}"/papermc-server-*.jar $SERVER_ARGS

--- a/src/test/docker/test.sh
+++ b/src/test/docker/test.sh
@@ -9,9 +9,24 @@ echo '📋 Testing the Docker PaperMC server image...'
 
 echo '▶️ Starting the PaperMC server in background...'
 
+# Apply security best practices based on OWASP recommendations:
+# https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html
+#
+# Simulate a production-like environment by enforcing strict security policies:
+# - Drop all Linux capabilities (PaperMC does not require any).
+# - Disable privilege escalation within the container.
+# - Set ulimits:
+#     - `nofile` (open files): 16384 — sufficient for typical Java-based Minecraft servers.
+#     - `nproc` (processes): 4096 — a safe and generous limit for JVM workloads.
+#     - `core`: 0 — disables core dumps to preserve disk space and avoid leaking sensitive information.
 docker run --rm -d --name "$CONTAINER_NAME" \
   --cap-drop all \
   --security-opt no-new-privileges \
+  --ulimit nofile=16384 \
+  --ulimit nproc=4096 \
+  --ulimit core=0 \
+  --cpus=4 \
+  --memory=8GB \
   -p 25565:25565/tcp -p 25565:25565/udp \
   -e EULA=true \
   'djaytan/papermc-server:dev'


### PR DESCRIPTION
See https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7-limit-resources-memory-cpu-file-descriptors-processes-restarts.