### PR TITLE
feat: setup healthcheck for resilience and high availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ $ docker run -d -it \
 * ☕ **JRE 21**, based on [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin)
   * Custom-built using `jlink` to minimize size
   * Includes all standard Java modules to ensure broad compatibility with plugins
+* 🩺 **Healthcheck integration**: Enhances resilience and high availability by continuously monitoring server health
+  with [`mc-monitor`](https://github.com/itzg/mc-monitor)
 * 🛡️ **Frequent security scans**: By relying on [Docker Scout](https://docs.docker.com/scout/)
 * 🔄 **Scheduled auto-updates**: Bi-monthly rebuilds to incorporate upstream security patches and PaperMC updates
 
@@ -58,7 +60,6 @@ $ docker run -d -it \
 
 The image is under active development, with the following enhancements planned:
 
-* 🩺 **Healthcheck integration**: Built-in Docker `HEALTHCHECK` instruction for better container observability.
 * ⚙️ **Unified configuration interface**: Centralized PaperMC tuning via a config file, with optional environment variable overrides (which will be the main difference with [itzg's solution](https://docker-minecraft-server.readthedocs.io/en/latest/configuration/interpolating/)).
   * **Customizable server startup options**: Ability to set JVM options and server properties via environment variables.
   * **Enable/Disable Aikar's flags**: Aikar's researches ([link](https://aikar.co/2018/07/02/tuning-the-jvm-g1gc-garbage-collector-flags-for-minecraft/)) and [PaperMC recommendations](https://docs.papermc.io/paper/aikars-flags/)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+# See https://docs.docker.com/build/metadata/attestations/sbom/#arguments
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 FROM docker.io/eclipse-temurin:21-jdk-alpine@sha256:2f2f553ce09d25e2d2f0f521ab94cd73f70c9b21327a29149c23a2b63b8e29a0 AS jre-build
@@ -31,6 +32,18 @@ RUN ${JAVA_HOME}/bin/jlink \
     --no-man-pages \
     --no-header-files \
     --output /jre
+
+# Use the official itzg/mc-monitor OCI image as a source for the mc-monitor binary.
+# This approach ensures:
+# - Compatibility with multi-arch builds (amd64, arm64) since the image is multi-platform.
+# - Simplified setup: avoids manual download/extraction logic and dependency handling.
+# - Automatic updates via Renovate (based on the image tag and digest).
+# The image is pinned by digest for reproducibility and supply-chain security,
+# while still allowing Renovate to track and update it as needed.
+#
+# The mc-monitor CLI is used for monitoring and health-checks purposes.
+# See https://github.com/itzg/mc-monitor
+FROM itzg/mc-monitor:0.15.5@sha256:301d416d2636be3461046f783853a45e095d974014751fea9b9c875ba782e1bf AS mc-monitor
 
 FROM docker.io/alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS papermc-server-build
 
@@ -67,6 +80,8 @@ COPY --from=jre-build /jre ${JAVA_HOME}
 # - gettext: is required for envsubst: https://pkgs.alpinelinux.org/package/edge/main/x86_64/gettext
 # - libudev-zero: is the Alpine-equivalent of libudev, which is required by PaperMC: https://pkgs.alpinelinux.org/package/edge/community/x86/libudev-zero
 RUN apk add --no-cache gettext libudev-zero
+
+COPY --from=mc-monitor --chmod=550 /mc-monitor /usr/local/bin/mc-monitor
 
 # Need to be turned to "true" manually to confirm agreement with Minecraft EULA (https://aka.ms/MinecraftEULA).
 ENV EULA=false
@@ -106,4 +121,5 @@ EXPOSE 25565
 
 ENTRYPOINT ["./start.sh"]
 
-# TODO: healthcheck
+HEALTHCHECK --interval=5s --timeout=3s --start-period=30s \
+  CMD ["mc-monitor", "status"]


### PR DESCRIPTION
Examples:

At startup:

```shell
$ docker inspect --format='{{json .State.Health}}' localdev-papermc-server | jq
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2025-05-10T22:31:29.272647674Z",
      "End": "2025-05-10T22:31:29.301945048Z",
      "ExitCode": 1,
      "Output": "failed to ping localhost:25565 : could not connect to Minecraft server: dial tcp [::1]:25565: connect: connection refused"
    },
    {
      "Start": "2025-05-10T22:31:34.302734266Z",
      "End": "2025-05-10T22:31:34.338783945Z",
      "ExitCode": 1,
      "Output": "failed to ping localhost:25565 : could not connect to Minecraft server: dial tcp [::1]:25565: connect: connection refused"
    },
    {
      "Start": "2025-05-10T22:31:39.339585221Z",
      "End": "2025-05-10T22:31:42.388609679Z",
      "ExitCode": -1,
      "Output": "Health check exceeded timeout (3s)"
    },
    {
      "Start": "2025-05-10T22:31:47.389134663Z",
      "End": "2025-05-10T22:31:47.424328594Z",
      "ExitCode": 0,
      "Output": "localhost:25565 : version=Paper 1.21.4 online=0 max=20 motd='A Minecraft Server'\n"
    }
  ]
}
```

At server closing time:

```shell
$ docker inspect --format='{{json .State.Health}}' localdev-papermc-server | jq
{
  "Status": "starting",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2025-05-10T22:32:07.512072468Z",
      "End": "2025-05-10T22:32:07.537132111Z",
      "ExitCode": 0,
      "Output": "localhost:25565 : version=Paper 1.21.4 online=0 max=20 motd='A Minecraft Server'\n"
    },
    {
      "Start": "2025-05-10T22:32:12.538098025Z",
      "End": "2025-05-10T22:32:12.563669227Z",
      "ExitCode": 0,
      "Output": "localhost:25565 : version=Paper 1.21.4 online=0 max=20 motd='A Minecraft Server'\n"
    },
    {
      "Start": "2025-05-10T22:32:17.564855041Z",
      "End": "2025-05-10T22:32:17.588690913Z",
      "ExitCode": 0,
      "Output": "localhost:25565 : version=Paper 1.21.4 online=0 max=20 motd='A Minecraft Server'\n"
    },
    {
      "Start": "2025-05-10T22:33:06.908973103Z",
      "End": "2025-05-10T22:33:06.936343359Z",
      "ExitCode": 0,
      "Output": "localhost:25565 : version=Paper 1.21.4 online=0 max=20 motd='A Minecraft Server'\n"
    },
    {
      "Start": "2025-05-10T22:33:14.146476913Z",
      "End": "2025-05-10T22:33:14.177900835Z",
      "ExitCode": 1,
      "Output": "failed to ping localhost:25565 : could not connect to Minecraft server: dial tcp [::1]:25565: connect: connection refused"
    }
  ]
}
```

`docker ps`:

```shell
$ docker ps
CONTAINER ID   IMAGE                        COMMAND        CREATED         STATUS                    PORTS                      NAMES
ff4f00ac0b60   djaytan/papermc-server:dev   "./start.sh"   2 minutes ago   Up 43 seconds (healthy)   0.0.0.0:25565->25565/tcp   localdev-papermc-server
```