### PR TITLE
ci: skip security scans on forks due to authentication issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -86,6 +87,7 @@ jobs:
 
       - name: Docker Scout
         uses: docker/scout-action@381b657c498a4d287752e7f2cfb2b41823f566d9 # v1.17.1
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           command: compare, cves
           image: 'djaytan/papermc-server:test'
@@ -95,6 +97,7 @@ jobs:
 
       - name: Upload to GitHub's code scanning dashboard
         uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           sarif_file: results.sarif
           # Use a fixed category to ensure consistent configuration across all SARIF uploads.


### PR DESCRIPTION
Secrets are not supported when builds are triggered by forks: https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.