### PR TITLE
fix: only inject the right category of envvar at config gen time

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ To override a configuration property using an environment variable, apply the fo
 
 | 🔖 Prefix               | 📄 Mapped Configuration File |
 |:------------------------|:-----------------------------|
-| `BUKKIT_`               | `bukkit.yml`                 |
+| `BUKKIT_GLOBAL_`        | `bukkit.yml`                 |
 | `BUKKIT_COMMANDS_`      | `commands.yml`               |
 | `BUKKIT_PERMISSIONS_`   | `permissions.yml`            |
 | `BUKKIT_HELP_`          | `help.yml`                   |
@@ -23,7 +23,7 @@ To override a configuration property using an environment variable, apply the fo
 | `PAPER_GLOBAL_`         | `paper-global.yml`           |
 | `PAPER_WORLD_DEFAULTS_` | `paper-world-defaults.yml`   |
 
-🧪 **Example:** The `bukkit.yml` property `settings.allow-end` becomes `BUKKIT_SETTINGS_ALLOW_END`.
+🧪 **Example:** The `bukkit.yml` property `settings.allow-end` becomes `BUKKIT_GLOBAL_SETTINGS_ALLOW_END`.
 
 Environment variables are suitable for simple setups. Configuration files (once supported) will enable customization of properties that cannot be set via
 environment variables (see details below) and will also simplify managing more complex configurations.

--- a/src/main/docker/runtime/config/base/bukkit.cue
+++ b/src/main/docker/runtime/config/base/bukkit.cue
@@ -4,34 +4,34 @@
 // TODO: make stronger types (e.g., specifying boundaries for integers, etc.)
 
 settings: {
-	"allow-end":           *true | bool              @tag(BUKKIT_SETTINGS_ALLOW_END, type=bool)
-	"warn-on-overload":    *true | bool              @tag(BUKKIT_SETTINGS_WARN_ON_OVERLOAD, type=bool)
+	"allow-end":           *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_ALLOW_END, type=bool)
+	"warn-on-overload":    *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_WARN_ON_OVERLOAD, type=bool)
 	"permissions-file":    "config/permissions.yml"  // System-managed property
-	"update-folder":       *"update" | string        @tag(BUKKIT_SETTINGS_UPDATE_FOLDER, type=string)
+	"update-folder":       *"update" | string        @tag(BUKKIT_GLOBAL_SETTINGS_UPDATE_FOLDER, type=string)
 	"plugin-profiling":    false                     // Disabled on PaperMC
-	"connection-throttle": *4000 | int               @tag(BUKKIT_SETTINGS_CONNECTION_THROTTLE, type=int)
-	"query-plugins":       *true | bool              @tag(BUKKIT_SETTINGS_QUERY_PLUGINS, type=bool)
-	"deprecated-verbose":  *"default" | string       @tag(BUKKIT_SETTINGS_DEPRECATED_VERBOSE, type=string)
-	"shutdown-message":    *"Server closed" | string @tag(BUKKIT_SETTINGS_SHUTDOWN_MESSAGE, type=string)
-	"minimum-api":         *"none" | string          @tag(BUKKIT_SETTINGS_MINIMUM_API, type=string)
-	"use-map-color-cache": *true | bool              @tag(BUKKIT_SETTINGS_USE_MAP_COLOR_CACHE, type=bool)
+	"connection-throttle": *4000 | int               @tag(BUKKIT_GLOBAL_SETTINGS_CONNECTION_THROTTLE, type=int)
+	"query-plugins":       *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_QUERY_PLUGINS, type=bool)
+	"deprecated-verbose":  *"default" | string       @tag(BUKKIT_GLOBAL_SETTINGS_DEPRECATED_VERBOSE, type=string)
+	"shutdown-message":    *"Server closed" | string @tag(BUKKIT_GLOBAL_SETTINGS_SHUTDOWN_MESSAGE, type=string)
+	"minimum-api":         *"none" | string          @tag(BUKKIT_GLOBAL_SETTINGS_MINIMUM_API, type=string)
+	"use-map-color-cache": *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_USE_MAP_COLOR_CACHE, type=bool)
 	"world-container":     "worlds"                  // System-managed property
 }
 
 // TODO: drop support in favor of Paper world config
 "spawn-limits": {
-	monsters:                     *70 | int @tag(BUKKIT_SPAWN_LIMITS_MONSTERS, type=int)
-	animals:                      *10 | int @tag(BUKKIT_SPAWN_LIMITS_ANIMALS, type=int)
-	"water-animals":              *5 | int  @tag(BUKKIT_SPAWN_LIMITS_WATER_ANIMALS, type=int)
-	"water-ambient":              *20 | int @tag(BUKKIT_SPAWN_LIMITS_WATER_AMBIENT, type=int)
-	"water-underground-creature": *5 | int  @tag(BUKKIT_SPAWN_LIMITS_WATER_UNDERGROUND_CREATURE, type=int)
-	axolotls:                     *5 | int  @tag(BUKKIT_SPAWN_LIMITS_AXOLOTLS, type=int)
-	ambient:                      *15 | int @tag(BUKKIT_SPAWN_LIMITS_AMBIENT, type=int)
+	monsters:                     *70 | int @tag(BUKKIT_GLOBAL_SPAWN_LIMITS_MONSTERS, type=int)
+	animals:                      *10 | int @tag(BUKKIT_GLOBAL_SPAWN_LIMITS_ANIMALS, type=int)
+	"water-animals":              *5 | int  @tag(BUKKIT_GLOBAL_SPAWN_LIMITS_WATER_ANIMALS, type=int)
+	"water-ambient":              *20 | int @tag(BUKKIT_GLOBAL_SPAWN_LIMITS_WATER_AMBIENT, type=int)
+	"water-underground-creature": *5 | int  @tag(BUKKIT_GLOBAL_SPAWN_LIMITS_WATER_UNDERGROUND_CREATURE, type=int)
+	axolotls:                     *5 | int  @tag(BUKKIT_GLOBAL_SPAWN_LIMITS_AXOLOTLS, type=int)
+	ambient:                      *15 | int @tag(BUKKIT_GLOBAL_SPAWN_LIMITS_AMBIENT, type=int)
 }
 
 // TODO: constrain properties (e.g. gc capped to 20 ticks by PaperMC) + document constraints
 "chunk-gc": {
-	"period-in-ticks": *600 | int @tag(BUKKIT_CHUNK_GC_PERIOD_IN_TICKS, type=int)
+	"period-in-ticks": *600 | int @tag(BUKKIT_GLOBAL_CHUNK_GC_PERIOD_IN_TICKS, type=int)
 }
 
 "ticks-per": {

--- a/src/main/docker/runtime/start.sh
+++ b/src/main/docker/runtime/start.sh
@@ -74,30 +74,32 @@ echo 'File eula.txt processed'
 # TODO: support custom Spark plugin version
 # TODO: Ensuire Timings v2 is disabled by default
 
-ENVVAR="$(env | grep -E '^(BUKKIT|SPIGOT|PAPER)_' | tr '\n' ',' | head -c -1)"
-
 generateConfig() {
   config_file="$1"
+  envvar_prefix="$2"
+  envvar="$(env | grep -E "^${envvar_prefix}" | tr '\n' ',' | head -c -1)"
   cue_file="${config_file%.yml}.cue"
+
+  echo "Generating configuration file \"${config_file}\"..."
 
   # Validate user-provided configuration property values
   cue vet "$cue_file" --concrete
 
   # Generate the configuration file
-  cue export "$cue_file" --inject "${ENVVAR}" --out yaml --outfile "$config_file"
+  cue export "$cue_file" --inject "${envvar}" --out yaml --outfile "$config_file"
 }
 
 # Bukkit
-generateConfig 'bukkit.yml'
-generateConfig 'config/commands.yml'
-generateConfig 'config/permissions.yml'
+generateConfig 'bukkit.yml' 'BUKKIT_GLOBAL_'
+generateConfig 'config/commands.yml' 'BUKKIT_COMMANDS_'
+generateConfig 'config/permissions.yml' 'BUKKIT_PERMISSIONS_'
 
 # Spigot
-generateConfig 'config/spigot.yml'
+generateConfig 'config/spigot.yml' 'SPIGOT_'
 
 # Paper
-generateConfig 'config/paper-global.yml'
-generateConfig 'config/paper-world-defaults.yml'
+generateConfig 'config/paper-global.yml' 'PAPER_GLOBAL_'
+generateConfig 'config/paper-world-defaults.yml' 'PAPER_WORLD_DEFAULTS_'
 
 # Clean-up CUE files after config generation
 find . -type f -name '*.cue' -exec rm -f {} +


### PR DESCRIPTION
This way we avoid the errors like "No tag for ...".

The fix required setting `bukkit.yml` properties prefix to `BUKKIT_GLOBAL_` instead of `BUKKIT_` for easy filtering of environment variables at config file generation time.