### PR TITLE
refactor: make all CUE files part of the `paper` CUE package

### DIFF
--- a/src/oci-image/runtime/config/bukkit.cue
+++ b/src/oci-image/runtime/config/bukkit.cue
@@ -3,6 +3,8 @@
 
 // TODO: try to define a kind of "var" field containing envvars, and try dynamic mapping?
 
+package paper
+
 bukkit: {
 	settings: {
 		"allow-end":           *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_ALLOW_END, type=bool)

--- a/src/oci-image/runtime/config/commands.cue
+++ b/src/oci-image/runtime/config/commands.cue
@@ -1,5 +1,7 @@
 // Specifications: https://docs.papermc.io/paper/reference/bukkit-commands-configuration/
 
+package paper
+
 bukkit: {
 	commands: {
 		"command-block-overrides": []

--- a/src/oci-image/runtime/config/paper-global.cue
+++ b/src/oci-image/runtime/config/paper-global.cue
@@ -8,6 +8,8 @@
 
 // TODO: ellipsis are unecessary
 
+package paper
+
 paper: {
 	"_version": 29 // Not customizable - Internal value only
 

--- a/src/oci-image/runtime/config/paper-world-defaults.cue
+++ b/src/oci-image/runtime/config/paper-world-defaults.cue
@@ -9,6 +9,8 @@
 // Any new fields added in future PaperMC versions can be safely added without breaking the existing configuration.
 // CUE structs are open by default. More info: https://cuelang.org/docs/tour/types/closed/
 
+package paper
+
 paper: {
 	"worlds-defaults": {
 		"_version": 30 // Not customizable - Internal value only

--- a/src/oci-image/runtime/config/permissions.cue
+++ b/src/oci-image/runtime/config/permissions.cue
@@ -1,6 +1,8 @@
 // Specifications: https://docs.papermc.io/paper/reference/bukkit-permissions-configuration/
 // TODO: implement
 
+package paper
+
 bukkit: {
 	permissions: {}
 }

--- a/src/oci-image/runtime/config/spigot.cue
+++ b/src/oci-image/runtime/config/spigot.cue
@@ -1,6 +1,8 @@
 // This is the main configuration file for Spigot.
 // Specifications: https://docs.papermc.io/paper/reference/spigot-configuration/
 
+package paper
+
 spigot: {
 	"config-version": 12 // Not customizable - Internal value only
 


### PR DESCRIPTION
This is a preliminary step prior supporting custom config files.