### PR TITLE
revert: improve forward-compatibility of exposed config properties

### DIFF
--- a/src/oci-image/runtime/config/cue/bukkit.cue
+++ b/src/oci-image/runtime/config/cue/bukkit.cue
@@ -8,18 +8,18 @@ package paper
 bukkit: {
 	global: {
 		settings: {
-			"allow-end":           *true | _                @tag(BUKKIT_GLOBAL_SETTINGS_ALLOW_END)
-			"warn-on-overload":    *true | _                @tag(BUKKIT_GLOBAL_SETTINGS_WARN_ON_OVERLOAD)
-			"permissions-file":    "config/permissions.yml" // System-managed property
-			"update-folder":       *"update" | _            @tag(BUKKIT_GLOBAL_SETTINGS_UPDATE_FOLDER)
-			"plugin-profiling":    false                    // Disabled on PaperMC
-			"connection-throttle": *4000 | _                @tag(BUKKIT_GLOBAL_SETTINGS_CONNECTION_THROTTLE)
-			"query-plugins":       *true | _                @tag(BUKKIT_GLOBAL_SETTINGS_QUERY_PLUGINS)
-			"deprecated-verbose":  *"default" | _           @tag(BUKKIT_GLOBAL_SETTINGS_DEPRECATED_VERBOSE)
-			"shutdown-message":    *"Server closed" | _     @tag(BUKKIT_GLOBAL_SETTINGS_SHUTDOWN_MESSAGE)
-			"minimum-api":         *"none" | _              @tag(BUKKIT_GLOBAL_SETTINGS_MINIMUM_API)
-			"use-map-color-cache": *true | _                @tag(BUKKIT_GLOBAL_SETTINGS_USE_MAP_COLOR_CACHE)
-			"world-container":     "worlds"                 // System-managed property
+			"allow-end":           *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_ALLOW_END, type=bool)
+			"warn-on-overload":    *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_WARN_ON_OVERLOAD, type=bool)
+			"permissions-file":    "config/permissions.yml"  // System-managed property
+			"update-folder":       *"update" | string        @tag(BUKKIT_GLOBAL_SETTINGS_UPDATE_FOLDER, type=string)
+			"plugin-profiling":    false                     // Disabled on PaperMC
+			"connection-throttle": *4000 | int               @tag(BUKKIT_GLOBAL_SETTINGS_CONNECTION_THROTTLE, type=int)
+			"query-plugins":       *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_QUERY_PLUGINS, type=bool)
+			"deprecated-verbose":  *"default" | string       @tag(BUKKIT_GLOBAL_SETTINGS_DEPRECATED_VERBOSE, type=string)
+			"shutdown-message":    *"Server closed" | string @tag(BUKKIT_GLOBAL_SETTINGS_SHUTDOWN_MESSAGE, type=string)
+			"minimum-api":         *"none" | string          @tag(BUKKIT_GLOBAL_SETTINGS_MINIMUM_API, type=string)
+			"use-map-color-cache": *true | bool              @tag(BUKKIT_GLOBAL_SETTINGS_USE_MAP_COLOR_CACHE, type=bool)
+			"world-container":     "worlds"                  // System-managed property
 		}
 
 		// These properties are overridden by PaperMC
@@ -34,7 +34,7 @@ bukkit: {
 		}
 
 		"chunk-gc": {
-			"period-in-ticks": *600 | _ @tag(BUKKIT_GLOBAL_CHUNK_GC_PERIOD_IN_TICKS)
+			"period-in-ticks": *600 | int @tag(BUKKIT_GLOBAL_CHUNK_GC_PERIOD_IN_TICKS, type=int)
 		}
 
 		// These properties are overridden by PaperMC

--- a/src/oci-image/runtime/config/cue/paper-global.cue
+++ b/src/oci-image/runtime/config/cue/paper-global.cue
@@ -10,162 +10,162 @@ paper: {
 		"_version": 29 // Not customizable - Internal value only
 
 		"block-updates": {
-			"disable-chorus-plant-updates":   *false | _ @tag(PAPER_GLOBAL_BLOCK_UPDATES_DISABLE_CHORUS_PLANT_UPDATES)
-			"disable-mushroom-block-updates": *false | _ @tag(PAPER_GLOBAL_BLOCK_UPDATES_DISABLE_MUSHROOM_BLOCK_UPDATES)
-			"disable-noteblock-updates":      *false | _ @tag(PAPER_GLOBAL_BLOCK_UPDATES_DISABLE_NOTEBLOCK_UPDATES)
-			"disable-tripwire-updates":       *false | _ @tag(PAPER_GLOBAL_BLOCK_UPDATES_DISABLE_TRIPWIRE_UPDATES)
+			"disable-chorus-plant-updates":   *false | bool @tag(PAPER_GLOBAL_BLOCK_UPDATES_DISABLE_CHORUS_PLANT_UPDATES, type=bool)
+			"disable-mushroom-block-updates": *false | bool @tag(PAPER_GLOBAL_BLOCK_UPDATES_DISABLE_MUSHROOM_BLOCK_UPDATES, type=bool)
+			"disable-noteblock-updates":      *false | bool @tag(PAPER_GLOBAL_BLOCK_UPDATES_DISABLE_NOTEBLOCK_UPDATES, type=bool)
+			"disable-tripwire-updates":       *false | bool @tag(PAPER_GLOBAL_BLOCK_UPDATES_DISABLE_TRIPWIRE_UPDATES, type=bool)
 		}
 
 		"chunk-loading": {
-			"autoconfig-send-distance":      *true | _  @tag(PAPER_GLOBAL_CHUNK_LOADING_AUTOCONFIG_SEND_DISTANCE)
-			"enable-frustum-priority":       *false | _ @tag(PAPER_GLOBAL_CHUNK_LOADING_ENABLE_FRUSTUM_PRIORITY)
-			"global-max-chunk-load-rate":    *-1.0 | _  @tag(PAPER_GLOBAL_CHUNK_LOADING_GLOBAL_MAX_CHUNK_LOAD_RATE)
-			"global-max-chunk-send-rate":    *-1.0 | _  @tag(PAPER_GLOBAL_CHUNK_LOADING_GLOBAL_MAX_CHUNK_SEND_RATE)
-			"global-max-concurrent-loads":   *500.0 | _ @tag(PAPER_GLOBAL_CHUNK_LOADING_GLOBAL_MAX_CONCURRENT_LOADS)
-			"max-concurrent-sends":          *2 | _     @tag(PAPER_GLOBAL_CHUNK_LOADING_MAX_CONCURRENT_SENDS)
-			"min-load-radius":               *2 | _     @tag(PAPER_GLOBAL_CHUNK_LOADING_MIN_LOAD_RADIUS)
-			"player-max-chunk-load-rate":    *-1.0 | _  @tag(PAPER_GLOBAL_CHUNK_LOADING_PLAYER_MAX_CHUNK_LOAD_RATE)
-			"player-max-concurrent-loads":   *20.0 | _  @tag(PAPER_GLOBAL_CHUNK_LOADING_PLAYER_MAX_CONCURRENT_LOADS)
-			"target-player-chunk-send-rate": *100.0 | _ @tag(PAPER_GLOBAL_CHUNK_LOADING_TARGET_PLAYER_CHUNK_SEND_RATE)
+			"autoconfig-send-distance":      *true | bool   @tag(PAPER_GLOBAL_CHUNK_LOADING_AUTOCONFIG_SEND_DISTANCE, type=bool)
+			"enable-frustum-priority":       *false | bool  @tag(PAPER_GLOBAL_CHUNK_LOADING_ENABLE_FRUSTUM_PRIORITY, type=bool)
+			"global-max-chunk-load-rate":    *-1.0 | float  @tag(PAPER_GLOBAL_CHUNK_LOADING_GLOBAL_MAX_CHUNK_LOAD_RATE, type=number)
+			"global-max-chunk-send-rate":    *-1.0 | float  @tag(PAPER_GLOBAL_CHUNK_LOADING_GLOBAL_MAX_CHUNK_SEND_RATE, type=number)
+			"global-max-concurrent-loads":   *500.0 | float @tag(PAPER_GLOBAL_CHUNK_LOADING_GLOBAL_MAX_CONCURRENT_LOADS, type=number)
+			"max-concurrent-sends":          *2 | int       @tag(PAPER_GLOBAL_CHUNK_LOADING_MAX_CONCURRENT_SENDS, type=int)
+			"min-load-radius":               *2 | int       @tag(PAPER_GLOBAL_CHUNK_LOADING_MIN_LOAD_RADIUS, type=int)
+			"player-max-chunk-load-rate":    *-1.0 | float  @tag(PAPER_GLOBAL_CHUNK_LOADING_PLAYER_MAX_CHUNK_LOAD_RATE, type=number)
+			"player-max-concurrent-loads":   *20.0 | float  @tag(PAPER_GLOBAL_CHUNK_LOADING_PLAYER_MAX_CONCURRENT_LOADS, type=number)
+			"target-player-chunk-send-rate": *100.0 | float @tag(PAPER_GLOBAL_CHUNK_LOADING_TARGET_PLAYER_CHUNK_SEND_RATE, type=number)
 		}
 
 		"chunk-loading-basic": {
-			"player-max-chunk-generate-rate": *-1.0 | _  @tag(PAPER_GLOBAL_CHUNK_LOADING_BASIC_PLAYER_MAX_CHUNK_GENERATE_RATE)
-			"player-max-chunk-load-rate":     *100.0 | _ @tag(PAPER_GLOBAL_CHUNK_LOADING_BASIC_PLAYER_MAX_CHUNK_LOAD_RATE)
-			"player-max-chunk-send-rate":     *75.0 | _  @tag(PAPER_GLOBAL_CHUNK_LOADING_BASIC_PLAYER_MAX_CHUNK_SEND_RATE)
+			"player-max-chunk-generate-rate": *-1.0 | float  @tag(PAPER_GLOBAL_CHUNK_LOADING_BASIC_PLAYER_MAX_CHUNK_GENERATE_RATE, type=number)
+			"player-max-chunk-load-rate":     *100.0 | float @tag(PAPER_GLOBAL_CHUNK_LOADING_BASIC_PLAYER_MAX_CHUNK_LOAD_RATE, type=number)
+			"player-max-chunk-send-rate":     *75.0 | float  @tag(PAPER_GLOBAL_CHUNK_LOADING_BASIC_PLAYER_MAX_CHUNK_SEND_RATE, type=number)
 		}
 
 		"chunk-loading-advanced": {
-			"auto-config-send-distance":             *true | _ @tag(PAPER_GLOBAL_CHUNK_LOADING_ADVANCED_AUTO_CONFIG_SEND_DISTANCE)
-			"player-max-concurrent-chunk-generates": *0 | _    @tag(PAPER_GLOBAL_CHUNK_LOADING_ADVANCED_PLAYER_MAX_CONCURRENT_CHUNK_GENERATES)
-			"player-max-concurrent-chunk-loads":     *0 | _    @tag(PAPER_GLOBAL_CHUNK_LOADING_ADVANCED_PLAYER_MAX_CONCURRENT_CHUNK_LOADS)
+			"auto-config-send-distance":             *true | bool @tag(PAPER_GLOBAL_CHUNK_LOADING_ADVANCED_AUTO_CONFIG_SEND_DISTANCE, type=bool)
+			"player-max-concurrent-chunk-generates": *0 | int     @tag(PAPER_GLOBAL_CHUNK_LOADING_ADVANCED_PLAYER_MAX_CONCURRENT_CHUNK_GENERATES, type=int)
+			"player-max-concurrent-chunk-loads":     *0 | int     @tag(PAPER_GLOBAL_CHUNK_LOADING_ADVANCED_PLAYER_MAX_CONCURRENT_CHUNK_LOADS, type=int)
 		}
 
 		"chunk-system": {
-			"gen-parallelism": *"default" | _ @tag(PAPER_GLOBAL_CHUNK_SYSTEM_GEN_PARALLELISM)
-			"io-threads":      *-1 | _        @tag(PAPER_GLOBAL_CHUNK_SYSTEM_IO_THREADS)
-			"worker-threads":  *-1 | _        @tag(PAPER_GLOBAL_CHUNK_SYSTEM_WORKER_THREADS)
+			"gen-parallelism": *"default" | string @tag(PAPER_GLOBAL_CHUNK_SYSTEM_GEN_PARALLELISM, type=string)
+			"io-threads":      *-1 | int           @tag(PAPER_GLOBAL_CHUNK_SYSTEM_IO_THREADS, type=int)
+			"worker-threads":  *-1 | int           @tag(PAPER_GLOBAL_CHUNK_SYSTEM_WORKER_THREADS, type=int)
 		}
 
 		collisions: {
-			"enable-player-collisions":                  *true | _ @tag(PAPER_GLOBAL_COLLISIONS_ENABLE_PLAYER_COLLISIONS)
-			"send-full-pos-for-hard-colliding-entities": *true | _ @tag(PAPER_GLOBAL_COLLISIONS_SEND_FULL_POS_FOR_HARD_COLLIDING_ENTITIES)
+			"enable-player-collisions":                  *true | bool @tag(PAPER_GLOBAL_COLLISIONS_ENABLE_PLAYER_COLLISIONS, type=bool)
+			"send-full-pos-for-hard-colliding-entities": *true | bool @tag(PAPER_GLOBAL_COLLISIONS_SEND_FULL_POS_FOR_HARD_COLLIDING_ENTITIES, type=bool)
 		}
 
 		commands: {
-			"fix-target-selector-tag-completion":             *true | _  @tag(PAPER_GLOBAL_COMMANDS_FIX_TARGET_SELECTOR_TAG_COMPLETION)
-			"suggest-player-names-when-null-tab-completions": *true | _  @tag(PAPER_GLOBAL_COMMANDS_SUGGEST_PLAYER_NAMES_WHEN_NULL_TAB_COMPLETIONS)
-			"time-command-affects-all-worlds":                *false | _ @tag(PAPER_GLOBAL_COMMANDS_TIME_COMMAND_AFFECTS_ALL_WORLDS)
+			"fix-target-selector-tag-completion":             *true | bool  @tag(PAPER_GLOBAL_COMMANDS_FIX_TARGET_SELECTOR_TAG_COMPLETION, type=bool)
+			"suggest-player-names-when-null-tab-completions": *true | bool  @tag(PAPER_GLOBAL_COMMANDS_SUGGEST_PLAYER_NAMES_WHEN_NULL_TAB_COMPLETIONS, type=bool)
+			"time-command-affects-all-worlds":                *false | bool @tag(PAPER_GLOBAL_COMMANDS_TIME_COMMAND_AFFECTS_ALL_WORLDS, type=bool)
 		}
 
 		console: {
-			"enable-brigadier-completions":  *true | _  @tag(PAPER_GLOBAL_CONSOLE_ENABLE_BRIGADIER_COMPLETIONS)
-			"enable-brigadier-highlighting": *true | _  @tag(PAPER_GLOBAL_CONSOLE_ENABLE_BRIGADIER_HIGHLIGHTING)
-			"has-all-permissions":           *false | _ @tag(PAPER_GLOBAL_CONSOLE_HAS_ALL_PERMISSIONS)
+			"enable-brigadier-completions":  *true | bool  @tag(PAPER_GLOBAL_CONSOLE_ENABLE_BRIGADIER_COMPLETIONS, type=bool)
+			"enable-brigadier-highlighting": *true | bool  @tag(PAPER_GLOBAL_CONSOLE_ENABLE_BRIGADIER_HIGHLIGHTING, type=bool)
+			"has-all-permissions":           *false | bool @tag(PAPER_GLOBAL_CONSOLE_HAS_ALL_PERMISSIONS, type=bool)
 		}
 
 		"item-validation": {
 			book: {
-				author: *8192 | _  @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_AUTHOR)
-				page:   *16384 | _ @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_PAGE)
-				title:  *8192 | _  @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_TITLE)
+				author: *8192 | int  @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_AUTHOR, type=int)
+				page:   *16384 | int @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_PAGE, type=int)
+				title:  *8192 | int  @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_TITLE, type=int)
 			}
 			"book-size": {
-				"page-max":         *2560 | _ @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_SIZE_PAGE_MAX)
-				"total-multiplier": *0.98 | _ @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_SIZE_TOTAL_MULTIPLIER)
+				"page-max":         *2560 | int   @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_SIZE_PAGE_MAX, type=int)
+				"total-multiplier": *0.98 | float @tag(PAPER_GLOBAL_ITEM_VALIDATION_BOOK_SIZE_TOTAL_MULTIPLIER, type=number)
 			}
-			"display-name":               *8192 | _  @tag(PAPER_GLOBAL_ITEM_VALIDATION_DISPLAY_NAME)
-			"lore-line":                  *8192 | _  @tag(PAPER_GLOBAL_ITEM_VALIDATION_LORE_LINE)
-			"resolve-selectors-in-books": *false | _ @tag(PAPER_GLOBAL_ITEM_VALIDATION_RESOLVE_SELECTORS_IN_BOOKS)
+			"display-name":               *8192 | int   @tag(PAPER_GLOBAL_ITEM_VALIDATION_DISPLAY_NAME, type=int)
+			"lore-line":                  *8192 | int   @tag(PAPER_GLOBAL_ITEM_VALIDATION_LORE_LINE, type=int)
+			"resolve-selectors-in-books": *false | bool @tag(PAPER_GLOBAL_ITEM_VALIDATION_RESOLVE_SELECTORS_IN_BOOKS, type=bool)
 		}
 
 		logging: {
-			"deobfuscate-stacktraces": *true | _ @tag(PAPER_GLOBAL_LOGGING_DEOBFUSCATE_STACKTRACES)
+			"deobfuscate-stacktraces": *true | bool @tag(PAPER_GLOBAL_LOGGING_DEOBFUSCATE_STACKTRACES, type=bool)
 		}
 
 		messages: {
 			kick: {
-				"authentication-servers-down": *"<lang:multiplayer.disconnect.authservers_down>" | _         @tag(PAPER_GLOBAL_MESSAGES_KICK_AUTHENTICATION_SERVERS_DOWN)
-				"connection-throttle":         *"Connection throttled! Please wait before reconnecting." | _ @tag(PAPER_GLOBAL_MESSAGES_KICK_CONNECTION_THROTTLE)
-				"flying-player":               *"<lang:multiplayer.disconnect.flying>" | _                   @tag(PAPER_GLOBAL_MESSAGES_KICK_FLYING_PLAYER)
-				"flying-vehicle":              *"<lang:multiplayer.disconnect.flying>" | _                   @tag(PAPER_GLOBAL_MESSAGES_KICK_FLYING_VEHICLE)
+				"authentication-servers-down": *"<lang:multiplayer.disconnect.authservers_down>" | string         @tag(PAPER_GLOBAL_MESSAGES_KICK_AUTHENTICATION_SERVERS_DOWN, type=string)
+				"connection-throttle":         *"Connection throttled! Please wait before reconnecting." | string @tag(PAPER_GLOBAL_MESSAGES_KICK_CONNECTION_THROTTLE, type=string)
+				"flying-player":               *"<lang:multiplayer.disconnect.flying>" | string                   @tag(PAPER_GLOBAL_MESSAGES_KICK_FLYING_PLAYER, type=string)
+				"flying-vehicle":              *"<lang:multiplayer.disconnect.flying>" | string                   @tag(PAPER_GLOBAL_MESSAGES_KICK_FLYING_VEHICLE, type=string)
 			}
-			"no-permission":                    *"<red>I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error." | _ @tag(PAPER_GLOBAL_MESSAGES_NO_PERMISSION)
-			"use-display-name-in-quit-message": *false | _                                                                                                                                                    @tag(PAPER_GLOBAL_MESSAGES_USE_DISPLAY_NAME_IN_QUIT_MESSAGE)
+			"no-permission":                    *"<red>I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error." | string @tag(PAPER_GLOBAL_MESSAGES_NO_PERMISSION, type=string)
+			"use-display-name-in-quit-message": *false | bool                                                                                                                                                      @tag(PAPER_GLOBAL_MESSAGES_USE_DISPLAY_NAME_IN_QUIT_MESSAGE, type=bool)
 		}
 
 		misc: {
 			"chat-threads": {
-				"chat-executor-core-size": *-1 | _ @tag(PAPER_GLOBAL_MISC_CHAT_THREADS_CHAT_EXECUTOR_CORE_SIZE)
-				"chat-executor-max-size":  *-1 | _ @tag(PAPER_GLOBAL_MISC_CHAT_THREADS_CHAT_EXECUTOR_MAX_SIZE)
+				"chat-executor-core-size": *-1 | int @tag(PAPER_GLOBAL_MISC_CHAT_THREADS_CHAT_EXECUTOR_CORE_SIZE, type=int)
+				"chat-executor-max-size":  *-1 | int @tag(PAPER_GLOBAL_MISC_CHAT_THREADS_CHAT_EXECUTOR_MAX_SIZE, type=int)
 			}
-			"compression-level":                      *"default" | _ @tag(PAPER_GLOBAL_MISC_COMPRESSION_LEVEL)
-			"fix-entity-position-desync":             *true | _      @tag(PAPER_GLOBAL_MISC_FIX_ENTITY_POSITION_DESYNC)
-			"lag-compensate-block-breaking":          *true | _      @tag(PAPER_GLOBAL_MISC_LAG_COMPENSATE_BLOCK_BREAKING)
-			"load-permissions-yml-before-plugins":    *true | _      @tag(PAPER_GLOBAL_MISC_LOAD_PERMISSIONS_YML_BEFORE_PLUGINS)
-			"max-joins-per-tick":                     *3 | _         @tag(PAPER_GLOBAL_MISC_MAX_JOINS_PER_TICK)
-			"region-file-cache-size":                 *256 | _       @tag(PAPER_GLOBAL_MISC_REGION_FILE_CACHE_SIZE)
-			"strict-advancement-dimension-check":     *false | _     @tag(PAPER_GLOBAL_MISC_STRICT_ADVANCEMENT_DIMENSION_CHECK)
-			"use-alternative-luck-formula":           *false | _     @tag(PAPER_GLOBAL_MISC_USE_ALTERNATIVE_LUCK_FORMULA)
-			"use-dimension-type-for-custom-spawners": *false | _     @tag(PAPER_GLOBAL_MISC_USE_DIMENSION_TYPE_FOR_CUSTOM_SPAWNERS)
+			"compression-level":                      *"default" | _ @tag(PAPER_GLOBAL_MISC_COMPRESSION_LEVEL, type=string)
+			"fix-entity-position-desync":             *true | bool   @tag(PAPER_GLOBAL_MISC_FIX_ENTITY_POSITION_DESYNC, type=bool)
+			"lag-compensate-block-breaking":          *true | bool   @tag(PAPER_GLOBAL_MISC_LAG_COMPENSATE_BLOCK_BREAKING, type=bool)
+			"load-permissions-yml-before-plugins":    *true | bool   @tag(PAPER_GLOBAL_MISC_LOAD_PERMISSIONS_YML_BEFORE_PLUGINS, type=bool)
+			"max-joins-per-tick":                     *3 | int       @tag(PAPER_GLOBAL_MISC_MAX_JOINS_PER_TICK, type=int)
+			"region-file-cache-size":                 *256 | int     @tag(PAPER_GLOBAL_MISC_REGION_FILE_CACHE_SIZE, type=int)
+			"strict-advancement-dimension-check":     *false | bool  @tag(PAPER_GLOBAL_MISC_STRICT_ADVANCEMENT_DIMENSION_CHECK, type=bool)
+			"use-alternative-luck-formula":           *false | bool  @tag(PAPER_GLOBAL_MISC_USE_ALTERNATIVE_LUCK_FORMULA, type=bool)
+			"use-dimension-type-for-custom-spawners": *false | bool  @tag(PAPER_GLOBAL_MISC_USE_DIMENSION_TYPE_FOR_CUSTOM_SPAWNERS, type=bool)
 		}
 
 		// Note: Mapping of the field "packet-limiter.override" to an environment variable is unsupported due to its complexity.
 		"packet-limiter": {
 			"all-packets": {
-				action:            *"KICK" | _ @tag(PAPER_GLOBAL_PACKET_LIMITER_ALL_PACKETS_ACTION)
-				interval:          *7.0 | _    @tag(PAPER_GLOBAL_PACKET_LIMITER_ALL_PACKETS_INTERVAL)
-				"max-packet-rate": *500.0 | _  @tag(PAPER_GLOBAL_PACKET_LIMITER_ALL_PACKETS_MAX_PACKET_RATE)
+				action:            *"KICK" | string @tag(PAPER_GLOBAL_PACKET_LIMITER_ALL_PACKETS_ACTION, type=string)
+				interval:          *7.0 | float     @tag(PAPER_GLOBAL_PACKET_LIMITER_ALL_PACKETS_INTERVAL, type=number)
+				"max-packet-rate": *500.0 | float   @tag(PAPER_GLOBAL_PACKET_LIMITER_ALL_PACKETS_MAX_PACKET_RATE, type=number)
 			}
-			"kick-message": *"<red><lang:disconnect.exceeded_packet_rate>" | _ @tag(PAPER_GLOBAL_PACKET_LIMITER_KICK_MESSAGE)
+			"kick-message": *"<red><lang:disconnect.exceeded_packet_rate>" | string @tag(PAPER_GLOBAL_PACKET_LIMITER_KICK_MESSAGE, type=string)
 		}
 
-		"play-in-use-item-spam-threshold": *300 | _ @tag(PAPER_GLOBAL_PLAY_IN_USE_ITEM_SPAM_THRESHOLD)
+		"play-in-use-item-spam-threshold": *300 | int @tag(PAPER_GLOBAL_PLAY_IN_USE_ITEM_SPAM_THRESHOLD, type=int)
 
 		"player-auto-save": {
-			"max-per-tick": *-1 | _ @tag(PAPER_GLOBAL_PLAYER_AUTO_SAVE_MAX_PER_TICK)
-			rate:           *-1 | _ @tag(PAPER_GLOBAL_PLAYER_AUTO_SAVE_RATE)
+			"max-per-tick": *-1 | int @tag(PAPER_GLOBAL_PLAYER_AUTO_SAVE_MAX_PER_TICK, type=int)
+			rate:           *-1 | int @tag(PAPER_GLOBAL_PLAYER_AUTO_SAVE_RATE, type=int)
 		}
 
 		proxies: {
 			"bungee-cord": {
-				"online-mode": *true | _ @tag(PAPER_GLOBAL_PROXIES_BUNGEE_CORD_ONLINE_MODE)
+				"online-mode": *true | bool @tag(PAPER_GLOBAL_PROXIES_BUNGEE_CORD_ONLINE_MODE, type=bool)
 			}
-			"proxy-protocol": *false | _ @tag(PAPER_GLOBAL_PROXIES_PROXY_PROTOCOL)
+			"proxy-protocol": *false | bool @tag(PAPER_GLOBAL_PROXIES_PROXY_PROTOCOL, type=bool)
 			velocity: {
-				enabled:       *false | _ @tag(PAPER_GLOBAL_PROXIES_VELOCITY_ENABLED)
-				"online-mode": *false | _ @tag(PAPER_GLOBAL_PROXIES_VELOCITY_ONLINE_MODE)
-				secret:        *"" | _    @tag(PAPER_GLOBAL_PROXIES_VELOCITY_SECRET)
+				enabled:       *false | bool @tag(PAPER_GLOBAL_PROXIES_VELOCITY_ENABLED, type=bool)
+				"online-mode": *false | bool @tag(PAPER_GLOBAL_PROXIES_VELOCITY_ONLINE_MODE, type=bool)
+				secret:        *"" | string  @tag(PAPER_GLOBAL_PROXIES_VELOCITY_SECRET, type=string)
 			}
 		}
 
 		scoreboards: {
-			"save-empty-scoreboard-teams": *false | _ @tag(PAPER_GLOBAL_SCOREBOARDS_SAVE_EMPTY_SCOREBOARD_TEAMS)
-			"track-plugin-scoreboards":    *false | _ @tag(PAPER_GLOBAL_SCOREBOARDS_TRACK_PLUGIN_SCOREBOARDS)
+			"save-empty-scoreboard-teams": *false | bool @tag(PAPER_GLOBAL_SCOREBOARDS_SAVE_EMPTY_SCOREBOARD_TEAMS, type=bool)
+			"track-plugin-scoreboards":    *false | bool @tag(PAPER_GLOBAL_SCOREBOARDS_TRACK_PLUGIN_SCOREBOARDS, type=bool)
 		}
 
 		"spam-limiter": {
-			"incoming-packet-threshold": *300 | _ @tag(PAPER_GLOBAL_SPAM_LIMITER_INCOMING_PACKET_THRESHOLD)
-			"recipe-spam-increment":     *1 | _   @tag(PAPER_GLOBAL_SPAM_LIMITER_RECIPE_SPAM_INCREMENT)
-			"recipe-spam-limit":         *20 | _  @tag(PAPER_GLOBAL_SPAM_LIMITER_RECIPE_SPAM_LIMIT)
-			"tab-spam-increment":        *1 | _   @tag(PAPER_GLOBAL_SPAM_LIMITER_TAB_SPAM_INCREMENT)
-			"tab-spam-limit":            *500 | _ @tag(PAPER_GLOBAL_SPAM_LIMITER_TAB_SPAM_LIMIT)
+			"incoming-packet-threshold": *300 | int @tag(PAPER_GLOBAL_SPAM_LIMITER_INCOMING_PACKET_THRESHOLD, type=int)
+			"recipe-spam-increment":     *1 | int   @tag(PAPER_GLOBAL_SPAM_LIMITER_RECIPE_SPAM_INCREMENT, type=int)
+			"recipe-spam-limit":         *20 | int  @tag(PAPER_GLOBAL_SPAM_LIMITER_RECIPE_SPAM_LIMIT, type=int)
+			"tab-spam-increment":        *1 | int   @tag(PAPER_GLOBAL_SPAM_LIMITER_TAB_SPAM_INCREMENT, type=int)
+			"tab-spam-limit":            *500 | int @tag(PAPER_GLOBAL_SPAM_LIMITER_TAB_SPAM_LIMIT, type=int)
 		}
 
 		"unsupported-settings": {
-			"allow-grindstone-overstacking":         *false | _  @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_GRINDSTONE_OVERSTACKING)
-			"allow-headless-pistons":                *false | _  @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_HEADLESS_PISTONS)
-			"allow-permanent-block-break-exploits":  *false | _  @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_PERMANENT_BLOCK_BREAK_EXPLOITS)
-			"allow-piston-duplication":              *false | _  @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_PISTON_DUPLICATION)
-			"allow-tripwire-disarming-exploits":     *false | _  @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_TRIPWIRE_DISARMING_EXPLOITS)
-			"allow-unsafe-end-portal-teleportation": *false | _  @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_UNSAFE_END_PORTAL_TELEPORTATION)
-			"compression-format":                    *"ZLIB" | _ @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_COMPRESSION_FORMAT)
-			"perform-username-validation":           *true | _   @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_PERFORM_USERNAME_VALIDATION)
+			"allow-grindstone-overstacking":         *false | bool    @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_GRINDSTONE_OVERSTACKING, type=bool)
+			"allow-headless-pistons":                *false | bool    @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_HEADLESS_PISTONS, type=bool)
+			"allow-permanent-block-break-exploits":  *false | bool    @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_PERMANENT_BLOCK_BREAK_EXPLOITS, type=bool)
+			"allow-piston-duplication":              *false | bool    @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_PISTON_DUPLICATION, type=bool)
+			"allow-tripwire-disarming-exploits":     *false | bool    @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_TRIPWIRE_DISARMING_EXPLOITS, type=bool)
+			"allow-unsafe-end-portal-teleportation": *false | bool    @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_ALLOW_UNSAFE_END_PORTAL_TELEPORTATION, type=bool)
+			"compression-format":                    *"ZLIB" | string @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_COMPRESSION_FORMAT, type=string)
+			"perform-username-validation":           *true | bool     @tag(PAPER_GLOBAL_UNSUPPORTED_SETTINGS_PERFORM_USERNAME_VALIDATION, type=bool)
 		}
 
 		watchdog: {
-			"early-warning-delay": *10000 | _ @tag(PAPER_GLOBAL_WATCHDOG_EARLY_WARNING_DELAY)
-			"early-warning-every": *5000 | _  @tag(PAPER_GLOBAL_WATCHDOG_EARLY_WARNING_EVERY)
+			"early-warning-delay": *10000 | int @tag(PAPER_GLOBAL_WATCHDOG_EARLY_WARNING_DELAY, type=int)
+			"early-warning-every": *5000 | int  @tag(PAPER_GLOBAL_WATCHDOG_EARLY_WARNING_EVERY, type=int)
 		}
 	}
 }

--- a/src/oci-image/runtime/config/cue/paper-world-defaults.cue
+++ b/src/oci-image/runtime/config/cue/paper-world-defaults.cue
@@ -12,13 +12,13 @@ paper: {
 		// TODO: support version 31
 		"_version": 30 // Not customizable - Internal value only
 
-		"allow-leashing-undead-horse": *false | _ @tag(PAPER_WORLD_DEFAULTS_ALLOW_LEASHING_UNDEAD_HORSE)
+		"allow-leashing-undead-horse": *false | bool @tag(PAPER_WORLD_DEFAULTS_ALLOW_LEASHING_UNDEAD_HORSE, type=bool)
 
 		anticheat: {
 			"anti-xray": {
-				"chunk-edge-mode": *1 | _     @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_CHUNK_EDGE_MODE)
-				enabled:           *false | _ @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_ENABLED)
-				"engine-mode":     *1 | _     @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_ENGINE_MODE)
+				"chunk-edge-mode": *1 | int      @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_CHUNK_EDGE_MODE, type=int)
+				enabled:           *false | bool @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_ENABLED, type=bool)
+				"engine-mode":     *1 | int      @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_ENGINE_MODE, type=int)
 				// No mapping to any environment variable for this field since unsupported due to its complexity.
 				"hidden-blocks": *[
 					"copper_ore",
@@ -42,295 +42,295 @@ paper: {
 					"emerald_ore",
 					"deepslate_emerald_ore",
 					"ender_chest",
-				] | _
-				"lava-obscures":           *false | _ @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_LAVA_OBSCURES)
-				"max-block-height":        *64 | _    @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_MAX_BLOCK_HEIGHT)
-				"max-chunk-section-index": *3 | _     @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_MAX_CHUNK_SECTION_INDEX)
+				] | [...string]
+				"lava-obscures":           *false | bool @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_LAVA_OBSCURES, type=bool)
+				"max-block-height":        *64 | int     @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_MAX_BLOCK_HEIGHT, type=int)
+				"max-chunk-section-index": *3 | int      @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_MAX_CHUNK_SECTION_INDEX, type=int)
 				// No mapping to any environment variable for this field since unsupported due to its complexity.
 				"replacement-blocks": *[
 					"stone",
 					"oak_planks",
 					"deepslate",
-				] | _
-				"update-radius":  *2 | _     @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_UPDATE_RADIUS)
-				"use-permission": *false | _ @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_USE_PERMISSION)
+				] | [...string]
+				"update-radius":  *2 | int      @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_UPDATE_RADIUS, type=int)
+				"use-permission": *false | bool @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_ANTI_XRAY_USE_PERMISSION, type=bool)
 			}
 			obfuscation: items: {
-				"hide-durability":                   *false | _ @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_OBFUSCATION_ITEMS_HIDE_DURABILITY)
-				"hide-itemmeta":                     *false | _ @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_OBFUSCATION_ITEMS_HIDE_ITEMMETA)
-				"hide-itemmeta-with-visual-effects": *false | _ @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_OBFUSCATION_ITEMS_HIDE_ITEMMETA_WITH_VISUAL_EFFECTS)
+				"hide-durability":                   *false | bool @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_OBFUSCATION_ITEMS_HIDE_DURABILITY, type=bool)
+				"hide-itemmeta":                     *false | bool @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_OBFUSCATION_ITEMS_HIDE_ITEMMETA, type=bool)
+				"hide-itemmeta-with-visual-effects": *false | bool @tag(PAPER_WORLD_DEFAULTS_ANTICHEAT_OBFUSCATION_ITEMS_HIDE_ITEMMETA_WITH_VISUAL_EFFECTS, type=bool)
 			}
 		}
 
-		"baby-zombie-movement-speed": *0.5 | _ @tag(PAPER_WORLD_DEFAULTS_BABY_ZOMBIE_MOVEMENT_SPEED)
+		"baby-zombie-movement-speed": *0.5 | float @tag(PAPER_WORLD_DEFAULTS_BABY_ZOMBIE_MOVEMENT_SPEED, type=number)
 
 		chunks: {
-			"auto-save-interval":     *6000 | _  @tag(PAPER_WORLD_DEFAULTS_CHUNKS_AUTO_SAVE_INTERVAL)
-			"delay-chunk-unloads-by": *"10s" | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_DELAY_CHUNK_UNLOADS_BY)
+			"auto-save-interval":     *6000 | int     @tag(PAPER_WORLD_DEFAULTS_CHUNKS_AUTO_SAVE_INTERVAL, type=int)
+			"delay-chunk-unloads-by": *"10s" | string @tag(PAPER_WORLD_DEFAULTS_CHUNKS_DELAY_CHUNK_UNLOADS_BY, type=string)
 			"entity-per-chunk-save-limit": {
-				arrow:          *-1 | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_ARROW)
-				ender_pearl:    *-1 | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_ENDER_PEARL)
-				experience_orb: *-1 | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_EXPERIENCE_ORB)
-				fireball:       *-1 | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_FIREBALL)
-				small_fireball: *-1 | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_SMALL_FIREBALL)
-				snowball:       *-1 | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_SNOWBALL)
+				arrow:          *-1 | int @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_ARROW, type=int)
+				ender_pearl:    *-1 | int @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_ENDER_PEARL, type=int)
+				experience_orb: *-1 | int @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_EXPERIENCE_ORB, type=int)
+				fireball:       *-1 | int @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_FIREBALL, type=int)
+				small_fireball: *-1 | int @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_SMALL_FIREBALL, type=int)
+				snowball:       *-1 | int @tag(PAPER_WORLD_DEFAULTS_CHUNKS_ENTITY_PER_CHUNK_SAVE_LIMIT_SNOWBALL, type=int)
 			}
-			"fixed-chunk-inhabited-time":          *-1 | _    @tag(PAPER_WORLD_DEFAULTS_CHUNKS_FIXED_CHUNK_INHABITED_TIME)
-			"flush-regions-on-save":               *false | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_FLUSH_REGIONS_ON_SAVE)
-			"max-auto-save-chunks-per-tick":       *24 | _    @tag(PAPER_WORLD_DEFAULTS_CHUNKS_MAX_AUTO_SAVE_CHUNKS_PER_TICK)
-			"prevent-moving-into-unloaded-chunks": *false | _ @tag(PAPER_WORLD_DEFAULTS_CHUNKS_PREVENT_MOVING_INTO_UNLOADED_CHUNKS)
+			"fixed-chunk-inhabited-time":          *-1 | int     @tag(PAPER_WORLD_DEFAULTS_CHUNKS_FIXED_CHUNK_INHABITED_TIME, type=int)
+			"flush-regions-on-save":               *false | bool @tag(PAPER_WORLD_DEFAULTS_CHUNKS_FLUSH_REGIONS_ON_SAVE, type=bool)
+			"max-auto-save-chunks-per-tick":       *24 | int     @tag(PAPER_WORLD_DEFAULTS_CHUNKS_MAX_AUTO_SAVE_CHUNKS_PER_TICK, type=int)
+			"prevent-moving-into-unloaded-chunks": *false | bool @tag(PAPER_WORLD_DEFAULTS_CHUNKS_PREVENT_MOVING_INTO_UNLOADED_CHUNKS, type=bool)
 		}
 
 		collisions: {
-			"allow-player-cramming-damage":         *false | _ @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_ALLOW_PLAYER_CRAMMING_DAMAGE)
-			"allow-vehicle-collisions":             *true | _  @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_ALLOW_VEHICLE_COLLISIONS)
-			"fix-climbing-bypassing-cramming-rule": *false | _ @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_FIX_CLIMBING_BYPASSING_CRAMMING_RULE)
-			"max-entity-collisions":                *8 | _     @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_MAX_ENTITY_COLLISIONS)
-			"only-players-collide":                 *false | _ @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_ONLY_PLAYERS_COLLIDE)
+			"allow-player-cramming-damage":         *false | bool @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_ALLOW_PLAYER_CRAMMING_DAMAGE, type=bool)
+			"allow-vehicle-collisions":             *true | bool  @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_ALLOW_VEHICLE_COLLISIONS, type=bool)
+			"fix-climbing-bypassing-cramming-rule": *false | bool @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_FIX_CLIMBING_BYPASSING_CRAMMING_RULE, type=bool)
+			"max-entity-collisions":                *8 | int      @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_MAX_ENTITY_COLLISIONS, type=int)
+			"only-players-collide":                 *false | bool @tag(PAPER_WORLD_DEFAULTS_COLLISIONS_ONLY_PLAYERS_COLLIDE, type=bool)
 		}
 
 		"command-blocks": {
-			"force-follow-perm-level": *true | _ @tag(PAPER_WORLD_DEFAULTS_COMMAND_BLOCKS_FORCE_FOLLOW_PERM_LEVEL)
-			"permissions-level":       *2 | _    @tag(PAPER_WORLD_DEFAULTS_COMMAND_BLOCKS_PERMISSIONS_LEVEL)
+			"force-follow-perm-level": *true | bool @tag(PAPER_WORLD_DEFAULTS_COMMAND_BLOCKS_FORCE_FOLLOW_PERM_LEVEL, type=bool)
+			"permissions-level":       *2 | int     @tag(PAPER_WORLD_DEFAULTS_COMMAND_BLOCKS_PERMISSIONS_LEVEL, type=int)
 		}
 
-		"enable-old-tnt-cannon-behaviors": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENABLE_OLD_TNT_CANNON_BEHAVIORS)
+		"enable-old-tnt-cannon-behaviors": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENABLE_OLD_TNT_CANNON_BEHAVIORS, type=bool)
 
 		entities: {
 			"armor-stands": {
-				"do-collision-entity-lookups": *true | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_ARMOR_STANDS_DO_COLLISION_ENTITY_LOOKUPS)
-				tick:                          *true | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_ARMOR_STANDS_TICK)
+				"do-collision-entity-lookups": *true | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_ARMOR_STANDS_DO_COLLISION_ENTITY_LOOKUPS, type=bool)
+				tick:                          *true | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_ARMOR_STANDS_TICK, type=bool)
 			}
 			behavior: {
-				"allow-spider-world-border-climbing": *true | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_ALLOW_SPIDER_WORLD_BORDER_CLIMBING)
-				"baby-zombie-movement-modifier":      *0.5 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_BABY_ZOMBIE_MOVEMENT_MODIFIER)
-				"disable-chest-cat-detection":        *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_DISABLE_CHEST_CAT_DETECTION)
-				"disable-creeper-lingering-effect":   *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_DISABLE_CREEPER_LINGERING_EFFECT)
-				"disable-player-crits":               *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_DISABLE_PLAYER_CRITS)
+				"allow-spider-world-border-climbing": *true | bool  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_ALLOW_SPIDER_WORLD_BORDER_CLIMBING, type=bool)
+				"baby-zombie-movement-modifier":      *0.5 | float  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_BABY_ZOMBIE_MOVEMENT_MODIFIER, type=number)
+				"disable-chest-cat-detection":        *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_DISABLE_CHEST_CAT_DETECTION, type=bool)
+				"disable-creeper-lingering-effect":   *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_DISABLE_CREEPER_LINGERING_EFFECT, type=bool)
+				"disable-player-crits":               *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_DISABLE_PLAYER_CRITS, type=bool)
 				// No mapping to any environment variable for this field since unsupported due to its complexity.
 				"door-breaking-difficulty": {
-					husk: *["HARD"] | _
-					vindicator: *["NORMAL", "HARD"] | _
-					zombie: *["HARD"] | _
-					zombie_villager: *["HARD"] | _
-					zombified_piglin: *["HARD"] | _
+					husk: *["HARD"] | [...string]
+					vindicator: *["NORMAL", "HARD"] | [...string]
+					zombie: *["HARD"] | [...string]
+					zombie_villager: *["HARD"] | [...string]
+					zombified_piglin: *["HARD"] | [...string]
 				}
-				"ender-dragons-death-always-places-dragon-egg": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_ENDER_DRAGONS_DEATH_ALWAYS_PLACES_DRAGON_EGG)
-				"experience-merge-max-value":                   *-1 | _    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_EXPERIENCE_MERGE_MAX_VALUE)
+				"ender-dragons-death-always-places-dragon-egg": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_ENDER_DRAGONS_DEATH_ALWAYS_PLACES_DRAGON_EGG, type=bool)
+				"experience-merge-max-value":                   *-1 | int     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_EXPERIENCE_MERGE_MAX_VALUE, type=int)
 				"mobs-can-always-pick-up-loot": {
-					skeletons: *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_MOBS_CAN_ALWAYS_PICK_UP_LOOT_SKELETONS)
-					zombies:   *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_MOBS_CAN_ALWAYS_PICK_UP_LOOT_ZOMBIES)
+					skeletons: *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_MOBS_CAN_ALWAYS_PICK_UP_LOOT_SKELETONS, type=bool)
+					zombies:   *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_MOBS_CAN_ALWAYS_PICK_UP_LOOT_ZOMBIES, type=bool)
 				}
-				"nerf-pigmen-from-nether-portals":           *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_NERF_PIGMEN_FROM_NETHER_PORTALS)
-				"parrots-are-unaffected-by-player-movement": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PARROTS_ARE_UNAFFECTED_BY_PLAYER_MOVEMENT)
-				"phantoms-do-not-spawn-on-creative-players": *true | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PHANTOMS_DO_NOT_SPAWN_ON_CREATIVE_PLAYERS)
-				"phantoms-only-attack-insomniacs":           *true | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PHANTOMS_ONLY_ATTACK_INSOMNIACS)
-				"phantoms-spawn-attempt-max-seconds":        *119 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PHANTOMS_SPAWN_ATTEMPT_MAX_SECONDS)
-				"phantoms-spawn-attempt-min-seconds":        *60 | _    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PHANTOMS_SPAWN_ATTEMPT_MIN_SECONDS)
-				"piglins-guard-chests":                      *true | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PIGLINS_GUARD_CHESTS)
+				"nerf-pigmen-from-nether-portals":           *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_NERF_PIGMEN_FROM_NETHER_PORTALS, type=bool)
+				"parrots-are-unaffected-by-player-movement": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PARROTS_ARE_UNAFFECTED_BY_PLAYER_MOVEMENT, type=bool)
+				"phantoms-do-not-spawn-on-creative-players": *true | bool  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PHANTOMS_DO_NOT_SPAWN_ON_CREATIVE_PLAYERS, type=bool)
+				"phantoms-only-attack-insomniacs":           *true | bool  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PHANTOMS_ONLY_ATTACK_INSOMNIACS, type=bool)
+				"phantoms-spawn-attempt-max-seconds":        *119 | int    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PHANTOMS_SPAWN_ATTEMPT_MAX_SECONDS, type=int)
+				"phantoms-spawn-attempt-min-seconds":        *60 | int     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PHANTOMS_SPAWN_ATTEMPT_MIN_SECONDS, type=int)
+				"piglins-guard-chests":                      *true | bool  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PIGLINS_GUARD_CHESTS, type=bool)
 				"pillager-patrols": {
-					disable:        *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_DISABLE)
-					"spawn-chance": *0.2 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_SPAWN_CHANCE)
+					disable:        *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_DISABLE, type=bool)
+					"spawn-chance": *0.2 | float  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_SPAWN_CHANCE, type=number)
 					"spawn-delay": {
-						"per-player": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_SPAWN_DELAY_PER_PLAYER)
-						ticks:        *12000 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_SPAWN_DELAY_TICKS)
+						"per-player": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_SPAWN_DELAY_PER_PLAYER, type=bool)
+						ticks:        *12000 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_SPAWN_DELAY_TICKS, type=int)
 					}
 					start: {
-						day:          *5 | _     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_START_DAY)
-						"per-player": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_START_PER_PLAYER)
+						day:          *5 | int      @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_START_DAY, type=int)
+						"per-player": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PILLAGER_PATROLS_START_PER_PLAYER, type=bool)
 					}
 				}
-				"player-insomnia-start-ticks":      *72000 | _     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PLAYER_INSOMNIA_START_TICKS)
-				"should-remove-dragon":             *false | _     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_SHOULD_REMOVE_DRAGON)
-				"spawner-nerfed-mobs-should-jump":  *false | _     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_SPAWNER_NERFED_MOBS_SHOULD_JUMP)
-				"zombie-villager-infection-chance": *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_ZOMBIE_VILLAGER_INFECTION_CHANCE)
-				"zombies-target-turtle-eggs":       *true | _      @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_ZOMBIES_TARGET_TURTLE_EGGS)
+				"player-insomnia-start-ticks":      *72000 | int                   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_PLAYER_INSOMNIA_START_TICKS, type=int)
+				"should-remove-dragon":             *false | bool                  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_SHOULD_REMOVE_DRAGON, type=bool)
+				"spawner-nerfed-mobs-should-jump":  *false | bool                  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_SPAWNER_NERFED_MOBS_SHOULD_JUMP, type=bool)
+				"zombie-villager-infection-chance": *"default" | "default" | float @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_ZOMBIE_VILLAGER_INFECTION_CHANCE, type=number)
+				"zombies-target-turtle-eggs":       *true | bool                   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_BEHAVIOR_ZOMBIES_TARGET_TURTLE_EGGS, type=bool)
 			}
-			"entities-target-with-follow-range": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_ENTITIES_TARGET_WITH_FOLLOW_RANGE)
+			"entities-target-with-follow-range": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_ENTITIES_TARGET_WITH_FOLLOW_RANGE, type=bool)
 			markers: {
-				tick: *true | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MARKERS_TICK)
+				tick: *true | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MARKERS_TICK, type=bool)
 			}
 			"mob-effects": {
 				"immune-to-wither-effect": {
-					wither:            *true | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MOB_EFFECTS_IMMUNE_TO_WITHER_EFFECT_WITHER)
-					"wither-skeleton": *true | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MOB_EFFECTS_IMMUNE_TO_WITHER_EFFECT_WITHER_SKELETON)
+					wither:            *true | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MOB_EFFECTS_IMMUNE_TO_WITHER_EFFECT_WITHER, type=bool)
+					"wither-skeleton": *true | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MOB_EFFECTS_IMMUNE_TO_WITHER_EFFECT_WITHER_SKELETON, type=bool)
 				}
-				"spiders-immune-to-poison-effect":  *true | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MOB_EFFECTS_SPIDERS_IMMUNE_TO_POISON_EFFECT)
-				"undead-immune-to-certain-effects": *true | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MOB_EFFECTS_UNDEAD_IMMUNE_TO_CERTAIN_EFFECTS)
+				"spiders-immune-to-poison-effect":  *true | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MOB_EFFECTS_SPIDERS_IMMUNE_TO_POISON_EFFECT, type=bool)
+				"undead-immune-to-certain-effects": *true | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_MOB_EFFECTS_UNDEAD_IMMUNE_TO_CERTAIN_EFFECTS, type=bool)
 			}
 			sniffer: {
-				"boosted-hatch-time": *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SNIFFER_BOOSTED_HATCH_TIME)
-				"hatch-time":         *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SNIFFER_HATCH_TIME)
+				"boosted-hatch-time": *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SNIFFER_BOOSTED_HATCH_TIME, type=int)
+				"hatch-time":         *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SNIFFER_HATCH_TIME, type=int)
 			}
 			spawning: {
-				"all-chunks-are-slime-chunks": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_ALL_CHUNKS_ARE_SLIME_CHUNKS)
+				"all-chunks-are-slime-chunks": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_ALL_CHUNKS_ARE_SLIME_CHUNKS, type=bool)
 				"alt-item-despawn-rate": {
-					enabled: *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_ALT_ITEM_DESPAWN_RATE_ENABLED)
+					enabled: *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_ALT_ITEM_DESPAWN_RATE_ENABLED, type=bool)
 					items: {
-						cobblestone: *300 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_ALT_ITEM_DESPAWN_RATE_ITEMS_COBBLESTONE)
+						cobblestone: *300 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_ALT_ITEM_DESPAWN_RATE_ITEMS_COBBLESTONE, type=int)
 					}
 				}
-				"count-all-mobs-for-spawning": *false | _     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_COUNT_ALL_MOBS_FOR_SPAWNING)
-				"creative-arrow-despawn-rate": *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_CREATIVE_ARROW_DESPAWN_RATE)
+				"count-all-mobs-for-spawning": *false | bool                @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_COUNT_ALL_MOBS_FOR_SPAWNING, type=bool)
+				"creative-arrow-despawn-rate": *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_CREATIVE_ARROW_DESPAWN_RATE, type=int)
 				"despawn-ranges": {
 					ambient: {
-						hard: *128 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_AMBIENT_HARD)
-						soft: *32 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_AMBIENT_SOFT)
+						hard: *128 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_AMBIENT_HARD, type=int)
+						soft: *32 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_AMBIENT_SOFT, type=int)
 					}
 					axolotls: {
-						hard: *128 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_AXOLOTLS_HARD)
-						soft: *32 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_AXOLOTLS_SOFT)
+						hard: *128 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_AXOLOTLS_HARD, type=int)
+						soft: *32 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_AXOLOTLS_SOFT, type=int)
 					}
 					creature: {
-						hard: *128 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_CREATURE_HARD)
-						soft: *32 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_CREATURE_SOFT)
+						hard: *128 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_CREATURE_HARD, type=int)
+						soft: *32 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_CREATURE_SOFT, type=int)
 					}
 					misc: {
-						hard: *128 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_MISC_HARD)
-						soft: *32 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_MISC_SOFT)
+						hard: *128 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_MISC_HARD, type=int)
+						soft: *32 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_MISC_SOFT, type=int)
 					}
 					monster: {
-						hard: *128 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_MONSTER_HARD)
-						soft: *32 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_MONSTER_SOFT)
+						hard: *128 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_MONSTER_HARD, type=int)
+						soft: *32 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_MONSTER_SOFT, type=int)
 					}
 					underground_water_creature: {
-						hard: *128 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_UNDERGROUND_WATER_CREATURE_HARD)
-						soft: *32 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_UNDERGROUND_WATER_CREATURE_SOFT)
+						hard: *128 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_UNDERGROUND_WATER_CREATURE_HARD, type=int)
+						soft: *32 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_UNDERGROUND_WATER_CREATURE_SOFT, type=int)
 					}
 					water_ambient: {
-						hard: *64 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_WATER_AMBIENT_HARD)
-						soft: *32 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_WATER_AMBIENT_SOFT)
+						hard: *64 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_WATER_AMBIENT_HARD, type=int)
+						soft: *32 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_WATER_AMBIENT_SOFT, type=int)
 					}
 					water_creature: {
-						hard: *128 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_WATER_CREATURE_HARD)
-						soft: *32 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_WATER_CREATURE_SOFT)
+						hard: *128 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_WATER_CREATURE_HARD, type=int)
+						soft: *32 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DESPAWN_RANGES_WATER_CREATURE_SOFT, type=int)
 					}
 				}
-				"disable-mob-spawner-spawn-egg-transformation": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DISABLE_MOB_SPAWNER_SPAWN_EGG_TRANSFORMATION)
+				"disable-mob-spawner-spawn-egg-transformation": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DISABLE_MOB_SPAWNER_SPAWN_EGG_TRANSFORMATION, type=bool)
 				"duplicate-uuid": {
-					mode:                      *"SAFE_REGEN" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DUPLICATE_UUID_MODE)
-					"safe-regen-delete-range": *32 | _           @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DUPLICATE_UUID_SAFE_REGEN_DELETE_RANGE)
+					mode:                      *"SAFE_REGEN" | string @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DUPLICATE_UUID_MODE, type=string)
+					"safe-regen-delete-range": *32 | int              @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_DUPLICATE_UUID_SAFE_REGEN_DELETE_RANGE, type=int)
 				}
-				"filter-bad-tile-entity-nbt-from-falling-blocks": *true | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_FILTER_BAD_TILE_ENTITY_NBT_FROM_FALLING_BLOCKS)
+				"filter-bad-tile-entity-nbt-from-falling-blocks": *true | bool @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_FILTER_BAD_TILE_ENTITY_NBT_FROM_FALLING_BLOCKS, type=bool)
 				// No mapping to any environment variable for this field since unsupported due to its complexity.
-				"filtered-entity-tag-nbt-paths": *["Pos", "Motion", "SleepingX", "SleepingY", "SleepingZ"] | _
-				"iron-golems-can-spawn-in-air":        *false | _     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_IRON_GOLEMS_CAN_SPAWN_IN_AIR)
-				"monster-spawn-max-light-level":       *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_MONSTER_SPAWN_MAX_LIGHT_LEVEL)
-				"non-player-arrow-despawn-rate":       *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_NON_PLAYER_ARROW_DESPAWN_RATE)
-				"per-player-mob-spawns":               *true | _      @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_PER_PLAYER_MOB_SPAWNS)
-				"scan-for-legacy-ender-dragon":        *true | _      @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SCAN_FOR_LEGACY_ENDER_DRAGON)
-				"skeleton-horse-thunder-spawn-chance": *0.01 | _      @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SKELETON_HORSE_THUNDER_SPAWN_CHANCE)
+				"filtered-entity-tag-nbt-paths": *["Pos", "Motion", "SleepingX", "SleepingY", "SleepingZ"] | [...string]
+				"iron-golems-can-spawn-in-air":        *false | bool                @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_IRON_GOLEMS_CAN_SPAWN_IN_AIR, type=bool)
+				"monster-spawn-max-light-level":       *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_MONSTER_SPAWN_MAX_LIGHT_LEVEL, type=int)
+				"non-player-arrow-despawn-rate":       *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_NON_PLAYER_ARROW_DESPAWN_RATE, type=int)
+				"per-player-mob-spawns":               *true | bool                 @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_PER_PLAYER_MOB_SPAWNS, type=bool)
+				"scan-for-legacy-ender-dragon":        *true | bool                 @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SCAN_FOR_LEGACY_ENDER_DRAGON, type=bool)
+				"skeleton-horse-thunder-spawn-chance": *0.01 | float                @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SKELETON_HORSE_THUNDER_SPAWN_CHANCE, type=number)
 				"slime-spawn-height": {
 					"slime-chunk": {
-						maximum: *40.0 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SLIME_SPAWN_HEIGHT_SLIME_CHUNK_MAXIMUM)
+						maximum: *40.0 | float @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SLIME_SPAWN_HEIGHT_SLIME_CHUNK_MAXIMUM, type=number)
 					}
 					"surface-biome": {
-						maximum: *70.0 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SLIME_SPAWN_HEIGHT_SURFACE_BIOME_MAXIMUM)
-						minimum: *50.0 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SLIME_SPAWN_HEIGHT_SURFACE_BIOME_MINIMUM)
+						maximum: *70.0 | float @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SLIME_SPAWN_HEIGHT_SURFACE_BIOME_MAXIMUM, type=number)
+						minimum: *50.0 | float @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SLIME_SPAWN_HEIGHT_SURFACE_BIOME_MINIMUM, type=number)
 					}
 				}
 				"spawn-limits": {
-					ambient:                    *15 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_AMBIENT)
-					axolotls:                   *5 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_AXOLOTLS)
-					creature:                   *10 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_CREATURE)
-					monster:                    *70 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_MONSTER)
-					underground_water_creature: *5 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_UNDERGROUND_WATER_CREATURE)
-					water_ambient:              *20 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_WATER_AMBIENT)
-					water_creature:             *5 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_WATER_CREATURE)
+					ambient:                    *15 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_AMBIENT, type=int)
+					axolotls:                   *5 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_AXOLOTLS, type=int)
+					creature:                   *10 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_CREATURE, type=int)
+					monster:                    *70 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_MONSTER, type=int)
+					underground_water_creature: *5 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_UNDERGROUND_WATER_CREATURE, type=int)
+					water_ambient:              *20 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_WATER_AMBIENT, type=int)
+					water_creature:             *5 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_SPAWN_LIMITS_WATER_CREATURE, type=int)
 				}
 				"ticks-per-spawn": {
-					ambient:                    *1 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_AMBIENT)
-					axolotls:                   *1 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_AXOLOTLS)
-					creature:                   *400 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_CREATURE)
-					monster:                    *1 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_MONSTER)
-					underground_water_creature: *1 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_UNDERGROUND_WATER_CREATURE)
-					water_ambient:              *1 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_WATER_AMBIENT)
-					water_creature:             *1 | _   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_WATER_CREATURE)
+					ambient:                    *1 | int   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_AMBIENT, type=int)
+					axolotls:                   *1 | int   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_AXOLOTLS, type=int)
+					creature:                   *400 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_CREATURE, type=int)
+					monster:                    *1 | int   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_MONSTER, type=int)
+					underground_water_creature: *1 | int   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_UNDERGROUND_WATER_CREATURE, type=int)
+					water_ambient:              *1 | int   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_WATER_AMBIENT, type=int)
+					water_creature:             *1 | int   @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_TICKS_PER_SPAWN_WATER_CREATURE, type=int)
 				}
 				"wandering-trader": {
-					"spawn-chance-failure-increment": *25 | _    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_CHANCE_FAILURE_INCREMENT)
-					"spawn-chance-max":               *75 | _    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_CHANCE_MAX)
-					"spawn-chance-min":               *25 | _    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_CHANCE_MIN)
-					"spawn-day-length":               *24000 | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_DAY_LENGTH)
-					"spawn-minute-length":            *1200 | _  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_MINUTE_LENGTH)
+					"spawn-chance-failure-increment": *25 | int    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_CHANCE_FAILURE_INCREMENT, type=int)
+					"spawn-chance-max":               *75 | int    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_CHANCE_MAX, type=int)
+					"spawn-chance-min":               *25 | int    @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_CHANCE_MIN, type=int)
+					"spawn-day-length":               *24000 | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_DAY_LENGTH, type=int)
+					"spawn-minute-length":            *1200 | int  @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WANDERING_TRADER_SPAWN_MINUTE_LENGTH, type=int)
 				}
 				"wateranimal-spawn-height": {
-					maximum: *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WATERANIMAL_SPAWN_HEIGHT_MAXIMUM)
-					minimum: *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WATERANIMAL_SPAWN_HEIGHT_MINIMUM)
+					maximum: *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WATERANIMAL_SPAWN_HEIGHT_MAXIMUM, type=int)
+					minimum: *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_SPAWNING_WATERANIMAL_SPAWN_HEIGHT_MINIMUM, type=int)
 				}
 			}
 			"tracking-range-y": {
-				animal:  *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_ANIMAL)
-				display: *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_DISPLAY)
-				enabled: *false | _     @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_ENABLED)
-				misc:    *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_MISC)
-				monster: *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_MONSTER)
-				other:   *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_OTHER)
-				player:  *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_PLAYER)
+				animal:  *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_ANIMAL, type=int)
+				display: *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_DISPLAY, type=int)
+				enabled: *false | bool                @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_ENABLED, type=bool)
+				misc:    *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_MISC, type=int)
+				monster: *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_MONSTER, type=int)
+				other:   *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_OTHER, type=int)
+				player:  *"default" | "default" | int @tag(PAPER_WORLD_DEFAULTS_ENTITIES_TRACKING_RANGE_Y_PLAYER, type=int)
 			}
 		}
 
 		environment: {
-			"disable-explosion-knockback":             *false | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_DISABLE_EXPLOSION_KNOCKBACK)
-			"disable-ice-and-snow":                    *false | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_DISABLE_ICE_AND_SNOW)
-			"disable-teleportation-suffocation-check": *false | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_DISABLE_TELEPORTATION_SUFFOCATION_CHECK)
-			"disable-thunder":                         *false | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_DISABLE_THUNDER)
-			"fire-tick-delay":                         *30 | _    @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_FIRE_TICK_DELAY)
+			"disable-explosion-knockback":             *false | bool @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_DISABLE_EXPLOSION_KNOCKBACK, type=bool)
+			"disable-ice-and-snow":                    *false | bool @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_DISABLE_ICE_AND_SNOW, type=bool)
+			"disable-teleportation-suffocation-check": *false | bool @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_DISABLE_TELEPORTATION_SUFFOCATION_CHECK, type=bool)
+			"disable-thunder":                         *false | bool @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_DISABLE_THUNDER, type=bool)
+			"fire-tick-delay":                         *30 | int     @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_FIRE_TICK_DELAY, type=int)
 			"frosted-ice": {
 				delay: {
-					max: *40 | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_FROSTED_ICE_DELAY_MAX)
-					min: *20 | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_FROSTED_ICE_DELAY_MIN)
+					max: *40 | int @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_FROSTED_ICE_DELAY_MAX, type=int)
+					min: *20 | int @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_FROSTED_ICE_DELAY_MIN, type=int)
 				}
-				enabled: *true | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_FROSTED_ICE_ENABLED)
+				enabled: *true | bool @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_FROSTED_ICE_ENABLED, type=bool)
 			}
-			"generate-flat-bedrock":                   *false | _      @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_GENERATE_FLAT_BEDROCK)
-			"max-block-ticks":                         *65536 | _      @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_MAX_BLOCK_TICKS)
-			"max-fluid-ticks":                         *65536 | _      @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_MAX_FLUID_TICKS)
-			"nether-ceiling-void-damage-height":       *"disabled" | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_NETHER_CEILING_VOID_DAMAGE_HEIGHT)
-			"optimize-explosions":                     *false | _      @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_OPTIMIZE_EXPLOSIONS)
-			"portal-create-radius":                    *16 | _         @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_PORTAL_CREATE_RADIUS)
-			"portal-search-radius":                    *128 | _        @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_PORTAL_SEARCH_RADIUS)
-			"portal-search-vanilla-dimension-scaling": *true | _       @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_PORTAL_SEARCH_VANILLA_DIMENSION_SCALING)
+			"generate-flat-bedrock":                   *false | bool                  @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_GENERATE_FLAT_BEDROCK, type=bool)
+			"max-block-ticks":                         *65536 | int                   @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_MAX_BLOCK_TICKS, type=int)
+			"max-fluid-ticks":                         *65536 | int                   @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_MAX_FLUID_TICKS, type=int)
+			"nether-ceiling-void-damage-height":       *"disabled" | "disabled" | int @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_NETHER_CEILING_VOID_DAMAGE_HEIGHT, type=int)
+			"optimize-explosions":                     *false | bool                  @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_OPTIMIZE_EXPLOSIONS, type=bool)
+			"portal-create-radius":                    *16 | int                      @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_PORTAL_CREATE_RADIUS, type=int)
+			"portal-search-radius":                    *128 | int                     @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_PORTAL_SEARCH_RADIUS, type=int)
+			"portal-search-vanilla-dimension-scaling": *true | bool                   @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_PORTAL_SEARCH_VANILLA_DIMENSION_SCALING, type=bool)
 			"treasure-maps": {
-				enabled: *true | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_TREASURE_MAPS_ENABLED)
+				enabled: *true | bool @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_TREASURE_MAPS_ENABLED, type=bool)
 				"find-already-discovered": {
-					"loot-tables":    *"default" | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_TREASURE_MAPS_FIND_ALREADY_DISCOVERED_LOOT_TABLES)
-					"villager-trade": *false | _     @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_TREASURE_MAPS_FIND_ALREADY_DISCOVERED_VILLAGER_TRADE)
+					"loot-tables":    *"default" | "default" | bool @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_TREASURE_MAPS_FIND_ALREADY_DISCOVERED_LOOT_TABLES, type=bool)
+					"villager-trade": *false | bool                 @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_TREASURE_MAPS_FIND_ALREADY_DISCOVERED_VILLAGER_TRADE, type=bool)
 				}
 			}
-			"water-over-lava-flow-speed": *5 | _ @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_WATER_OVER_LAVA_FLOW_SPEED)
+			"water-over-lava-flow-speed": *5 | int @tag(PAPER_WORLD_DEFAULTS_ENVIRONMENT_WATER_OVER_LAVA_FLOW_SPEED, type=int)
 		}
 
 		"feature-seeds": {
-			"generate-random-seeds-for-all": *false | _ @tag(PAPER_WORLD_DEFAULTS_FEATURE_SEEDS_GENERATE_RANDOM_SEEDS_FOR_ALL)
+			"generate-random-seeds-for-all": *false | bool @tag(PAPER_WORLD_DEFAULTS_FEATURE_SEEDS_GENERATE_RANDOM_SEEDS_FOR_ALL, type=bool)
 		}
 
 		"fishing-time-range": {
-			maximum: *600 | _ @tag(PAPER_WORLD_DEFAULTS_FISHING_TIME_RANGE_MAXIMUM)
-			minimum: *100 | _ @tag(PAPER_WORLD_DEFAULTS_FISHING_TIME_RANGE_MINIMUM)
+			maximum: *600 | int @tag(PAPER_WORLD_DEFAULTS_FISHING_TIME_RANGE_MAXIMUM, type=int)
+			minimum: *100 | int @tag(PAPER_WORLD_DEFAULTS_FISHING_TIME_RANGE_MINIMUM, type=int)
 		}
 
 		fixes: {
-			"disable-unloaded-chunk-enderpearl-exploit": *true | _       @tag(PAPER_WORLD_DEFAULTS_FIXES_DISABLE_UNLOADED_CHUNK_ENDERPEARL_EXPLOIT)
-			"falling-block-height-nerf":                 *"disabled" | _ @tag(PAPER_WORLD_DEFAULTS_FIXES_FALLING_BLOCK_HEIGHT_NERF)
-			"fix-items-merging-through-walls":           *false | _      @tag(PAPER_WORLD_DEFAULTS_FIXES_FIX_ITEMS_MERGING_THROUGH_WALLS)
-			"prevent-tnt-from-moving-in-water":          *false | _      @tag(PAPER_WORLD_DEFAULTS_FIXES_PREVENT_TNT_FROM_MOVING_IN_WATER)
-			"remove-corrupt-tile-entities":              *false | _      @tag(PAPER_WORLD_DEFAULTS_FIXES_REMOVE_CORRUPT_TILE_ENTITIES)
-			"split-overstacked-loot":                    *true | _       @tag(PAPER_WORLD_DEFAULTS_FIXES_SPLIT_OVERSTACKED_LOOT)
-			"tnt-entity-height-nerf":                    *"disabled" | _ @tag(PAPER_WORLD_DEFAULTS_FIXES_TNT_ENTITY_HEIGHT_NERF)
+			"disable-unloaded-chunk-enderpearl-exploit": *true | bool                   @tag(PAPER_WORLD_DEFAULTS_FIXES_DISABLE_UNLOADED_CHUNK_ENDERPEARL_EXPLOIT, type=bool)
+			"falling-block-height-nerf":                 *"disabled" | "disabled" | int @tag(PAPER_WORLD_DEFAULTS_FIXES_FALLING_BLOCK_HEIGHT_NERF, type=int)
+			"fix-items-merging-through-walls":           *false | bool                  @tag(PAPER_WORLD_DEFAULTS_FIXES_FIX_ITEMS_MERGING_THROUGH_WALLS, type=bool)
+			"prevent-tnt-from-moving-in-water":          *false | bool                  @tag(PAPER_WORLD_DEFAULTS_FIXES_PREVENT_TNT_FROM_MOVING_IN_WATER, type=bool)
+			"remove-corrupt-tile-entities":              *false | bool                  @tag(PAPER_WORLD_DEFAULTS_FIXES_REMOVE_CORRUPT_TILE_ENTITIES, type=bool)
+			"split-overstacked-loot":                    *true | bool                   @tag(PAPER_WORLD_DEFAULTS_FIXES_SPLIT_OVERSTACKED_LOOT, type=bool)
+			"tnt-entity-height-nerf":                    *"disabled" | "disabled" | int @tag(PAPER_WORLD_DEFAULTS_FIXES_TNT_ENTITY_HEIGHT_NERF, type=int)
 		}
 
 		hopper: {
-			"cooldown-when-full":      *true | _  @tag(PAPER_WORLD_DEFAULTS_HOPPER_COOLDOWN_WHEN_FULL)
-			"disable-move-event":      *false | _ @tag(PAPER_WORLD_DEFAULTS_HOPPER_DISABLE_MOVE_EVENT)
-			"ignore-occluding-blocks": *false | _ @tag(PAPER_WORLD_DEFAULTS_HOPPER_IGNORE_OCCLUDING_BLOCKS)
-			"push-based":              *false | _ @tag(PAPER_WORLD_DEFAULTS_HOPPER_PUSH_BASED)
+			"cooldown-when-full":      *true | bool  @tag(PAPER_WORLD_DEFAULTS_HOPPER_COOLDOWN_WHEN_FULL, type=bool)
+			"disable-move-event":      *false | bool @tag(PAPER_WORLD_DEFAULTS_HOPPER_DISABLE_MOVE_EVENT, type=bool)
+			"ignore-occluding-blocks": *false | bool @tag(PAPER_WORLD_DEFAULTS_HOPPER_IGNORE_OCCLUDING_BLOCKS, type=bool)
+			"push-based":              *false | bool @tag(PAPER_WORLD_DEFAULTS_HOPPER_PUSH_BASED, type=bool)
 		}
 
 		lootables: {
-			"auto-replenish": *false | _ @tag(PAPER_WORLD_DEFAULTS_LOOTABLES_AUTO_REPLENISH)
-			"max-refills":    *-1 | _    @tag(PAPER_WORLD_DEFAULTS_LOOTABLES_MAX_REFILLS)
-			"refresh-max":    *"2d" | _  @tag(PAPER_WORLD_DEFAULTS_LOOTABLES_REFRESH_MAX)
+			"auto-replenish": *false | bool  @tag(PAPER_WORLD_DEFAULTS_LOOTABLES_AUTO_REPLENISH, type=bool)
+			"max-refills":    *-1 | int      @tag(PAPER_WORLD_DEFAULTS_LOOTABLES_MAX_REFILLS, type=int)
+			"refresh-max":    *"2d" | string @tag(PAPER_WORLD_DEFAULTS_LOOTABLES_REFRESH_MAX, type=string)
 		}
 	}
 }

--- a/src/oci-image/runtime/config/cue/spigot.cue
+++ b/src/oci-image/runtime/config/cue/spigot.cue
@@ -7,204 +7,204 @@ spigot: {
 	"config-version": 12 // Not customizable - Internal value only
 
 	messages: {
-		whitelist:         *"You are not whitelisted on this server!" | _   @tag(SPIGOT_MESSAGES_WHITELIST)
-		"unknown-command": *"Unknown command. Type \"/help\" for help." | _ @tag(SPIGOT_MESSAGES_UNKNOWN_COMMAND)
-		"server-full":     *"The server is full!" | _                       @tag(SPIGOT_MESSAGES_SERVER_FULL)
-		"outdated-client": *"Outdated client! Please use {0}" | _           @tag(SPIGOT_MESSAGES_OUTDATED_CLIENT)
-		"outdated-server": *"Outdated server! I'm still on {0}" | _         @tag(SPIGOT_MESSAGES_OUTDATED_SERVER)
-		restart:           *"Server is restarting" | _                      @tag(SPIGOT_MESSAGES_RESTART)
+		whitelist:         *"You are not whitelisted on this server!" | string   @tag(SPIGOT_MESSAGES_WHITELIST, type=string)
+		"unknown-command": *"Unknown command. Type \"/help\" for help." | string @tag(SPIGOT_MESSAGES_UNKNOWN_COMMAND, type=string)
+		"server-full":     *"The server is full!" | string                       @tag(SPIGOT_MESSAGES_SERVER_FULL, type=string)
+		"outdated-client": *"Outdated client! Please use {0}" | string           @tag(SPIGOT_MESSAGES_OUTDATED_CLIENT, type=string)
+		"outdated-server": *"Outdated server! I'm still on {0}" | string         @tag(SPIGOT_MESSAGES_OUTDATED_SERVER, type=string)
+		restart:           *"Server is restarting" | string                      @tag(SPIGOT_MESSAGES_RESTART, type=string)
 	}
 
 	commands: {
-		"tab-complete":    *0 | _    @tag(SPIGOT_COMMANDS_TAB_COMPLETE)
-		"send-namespaced": *true | _ @tag(SPIGOT_COMMANDS_SEND_NAMESPACED)
+		"tab-complete":    *0 | int     @tag(SPIGOT_COMMANDS_TAB_COMPLETE, type=int)
+		"send-namespaced": *true | bool @tag(SPIGOT_COMMANDS_SEND_NAMESPACED, type=bool)
 		// No mapping to any environment variable for this field since unsupported due to its complexity.
-		"spam-exclusions": *["/skill"] | _
+		"spam-exclusions": *["/skill"] | [...string]
 		// No mapping to any environment variable for this field since unsupported due to its complexity.
 		"replace-commands": *[
 			"setblock",
 			"summon",
 			"testforblock",
 			"tellraw",
-		] | _
-		log:                           *true | _  @tag(SPIGOT_COMMANDS_LOG)
-		"silent-commandblock-console": *false | _ @tag(SPIGOT_COMMANDS_SILENT_COMMANDBLOCK_CONSOLE)
+		] | [...string]
+		log:                           *true | bool  @tag(SPIGOT_COMMANDS_LOG, type=bool)
+		"silent-commandblock-console": *false | bool @tag(SPIGOT_COMMANDS_SILENT_COMMANDBLOCK_CONSOLE, type=bool)
 	}
 
 	settings: {
-		bungeecord: *false | _ @tag(SPIGOT_SETTINGS_BUNGEECORD)
+		bungeecord: *false | bool @tag(SPIGOT_SETTINGS_BUNGEECORD, type=bool)
 		attribute: {
 			maxAbsorption: {
-				max: *2048.0 | _ @tag(SPIGOT_SETTINGS_ATTRIBUTE_MAX_ABSORPTION)
+				max: *2048.0 | float @tag(SPIGOT_SETTINGS_ATTRIBUTE_MAX_ABSORPTION, type=number)
 			}
 			maxHealth: {
-				max: *1024.0 | _ @tag(SPIGOT_SETTINGS_ATTRIBUTE_MAX_HEALTH)
+				max: *1024.0 | float @tag(SPIGOT_SETTINGS_ATTRIBUTE_MAX_HEALTH, type=number)
 			}
 			movementSpeed: {
-				max: *1024.0 | _ @tag(SPIGOT_SETTINGS_ATTRIBUTE_MAX_MOVEMENT_SPEED)
+				max: *1024.0 | float @tag(SPIGOT_SETTINGS_ATTRIBUTE_MAX_MOVEMENT_SPEED, type=number)
 			}
 			attackDamage: {
-				max: *2048.0 | _ @tag(SPIGOT_SETTINGS_ATTRIBUTE_MAX_ATTACK_DAMAGE)
+				max: *2048.0 | float @tag(SPIGOT_SETTINGS_ATTRIBUTE_MAX_ATTACK_DAMAGE, type=number)
 			}
 		}
-		"user-cache-size":              *1000 | _   @tag(SPIGOT_SETTINGS_USER_CACHE_SIZE)
-		"netty-threads":                *4 | _      @tag(SPIGOT_SETTINGS_NETTY_THREADS)
-		"player-shuffle":               *0 | _      @tag(SPIGOT_SETTINGS_PLAYER_SHUFFLE)
-		"moved-wrongly-threshold":      *0.0625 | _ @tag(SPIGOT_SETTINGS_MOVED_WRONGLY_THRESHOLD)
-		"moved-too-quickly-multiplier": *10.0 | _   @tag(SPIGOT_SETTINGS_MOVED_TOO_QUICKLY_MULTIPLIER)
-		"log-villager-deaths":          *true | _   @tag(SPIGOT_SETTINGS_LOG_VILLAGER_DEATHS)
-		"log-named-deaths":             *true | _   @tag(SPIGOT_SETTINGS_LOG_NAMED_DEATHS)
-		"timeout-time":                 *30 | _     @tag(SPIGOT_SETTINGS_TIMEOUT_TIME)
+		"user-cache-size":              *1000 | int     @tag(SPIGOT_SETTINGS_USER_CACHE_SIZE, type=int)
+		"netty-threads":                *4 | int        @tag(SPIGOT_SETTINGS_NETTY_THREADS, type=int)
+		"player-shuffle":               *0 | int        @tag(SPIGOT_SETTINGS_PLAYER_SHUFFLE, type=int)
+		"moved-wrongly-threshold":      *0.0625 | float @tag(SPIGOT_SETTINGS_MOVED_WRONGLY_THRESHOLD, type=number)
+		"moved-too-quickly-multiplier": *10.0 | int     @tag(SPIGOT_SETTINGS_MOVED_TOO_QUICKLY_MULTIPLIER, type=number)
+		"log-villager-deaths":          *true | bool    @tag(SPIGOT_SETTINGS_LOG_VILLAGER_DEATHS, type=bool)
+		"log-named-deaths":             *true | bool    @tag(SPIGOT_SETTINGS_LOG_NAMED_DEATHS, type=bool)
+		"timeout-time":                 *30 | int       @tag(SPIGOT_SETTINGS_TIMEOUT_TIME, type=int)
 		// TODO: check https://gist.github.com/Prof-Bloodstone/6367eb4016eaf9d1646a88772cdbbac5
 		"restart-on-crash":             false         // System-managed property (only rely on Docker restart policy)
 		"restart-script":               "unsupported" // System-managed property (only rely on Docker restart policy)
-		"save-user-cache-on-stop-only": *false | _    @tag(SPIGOT_SETTINGS_SAVE_USER_CACHE_ON_STOP_ONLY)
-		"sample-count":                 *12 | _       @tag(SPIGOT_SETTINGS_SAMPLE_COUNT)
-		debug:                          *false | _    @tag(SPIGOT_SETTINGS_DEBUG)
+		"save-user-cache-on-stop-only": *false | bool @tag(SPIGOT_SETTINGS_SAVE_USER_CACHE_ON_STOP_ONLY, type=bool)
+		"sample-count":                 *12 | int     @tag(SPIGOT_SETTINGS_SAMPLE_COUNT, type=int)
+		debug:                          *false | bool @tag(SPIGOT_SETTINGS_DEBUG, type=bool)
 	}
 
 	players: {
-		"disable-saving": *false | _ @tag(SPIGOT_PLAYERS_DISABLE_SAVING)
+		"disable-saving": *false | bool @tag(SPIGOT_PLAYERS_DISABLE_SAVING, type=bool)
 	}
 
 	advancements: {
-		"disable-saving": *false | _ @tag(SPIGOT_ADVANCEMENTS_DISABLE_SAVING)
+		"disable-saving": *false | bool @tag(SPIGOT_ADVANCEMENTS_DISABLE_SAVING, type=bool)
 		// No mapping to any environment variable for this field since unsupported due to its complexity.
-		disabled: *["minecraft:story/disabled"] | _
+		disabled: *["minecraft:story/disabled"] | [...string]
 	}
 
 	// No mapping to any environment variable for world-specific settings (only default settings are mapped).
 	// TODO: support world-specific settings
 	// TODO: move into separate file (e.g., spigot-world-defaults.cue)
 	"world-settings": default: {
-		"below-zero-generation-in-existing-chunks": *true | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_BELOW_ZERO_GENERATION_IN_EXISTING_CHUNKS)
-		"mob-spawn-range":                          *8 | _         @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MOB_SPAWN_RANGE)
-		"item-despawn-rate":                        *6000 | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ITEM_DESPAWN_RATE)
-		"thunder-chance":                           *100000 | _    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_THUNDER_CHANCE)
-		"simulation-distance":                      *"default" | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SIMULATION_DISTANCE)
-		"view-distance":                            *"default" | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_VIEW_DISTANCE)
-		"zombie-aggressive-towards-villager":       *true | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ZOMBIE_AGGRESSIVE_TOWARDS_VILLAGER)
-		"enable-zombie-pigmen-portal-spawns":       *true | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENABLE_ZOMBIE_PIGMEN_PORTAL_SPAWNS)
-		"dragon-death-sound-radius":                *0 | _         @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_DRAGON_DEATH_SOUND_RADIUS)
-		"wither-spawn-sound-radius":                *0 | _         @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_WITHER_SPAWN_SOUND_RADIUS)
-		"end-portal-sound-radius":                  *0 | _         @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_END_PORTAL_SOUND_RADIUS)
-		"hanging-tick-frequency":                   *100 | _       @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HANGING_TICK_FREQUENCY)
+		"below-zero-generation-in-existing-chunks": *true | bool                 @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_BELOW_ZERO_GENERATION_IN_EXISTING_CHUNKS, type=bool)
+		"mob-spawn-range":                          *8 | int                     @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MOB_SPAWN_RANGE, type=int)
+		"item-despawn-rate":                        *6000 | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ITEM_DESPAWN_RATE, type=int)
+		"thunder-chance":                           *100000 | int                @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_THUNDER_CHANCE, type=int)
+		"simulation-distance":                      *"default" | "default" | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SIMULATION_DISTANCE, type=int)
+		"view-distance":                            *"default" | "default" | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_VIEW_DISTANCE, type=int)
+		"zombie-aggressive-towards-villager":       *true | bool                 @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ZOMBIE_AGGRESSIVE_TOWARDS_VILLAGER, type=bool)
+		"enable-zombie-pigmen-portal-spawns":       *true | bool                 @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENABLE_ZOMBIE_PIGMEN_PORTAL_SPAWNS, type=bool)
+		"dragon-death-sound-radius":                *0 | int                     @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_DRAGON_DEATH_SOUND_RADIUS, type=int)
+		"wither-spawn-sound-radius":                *0 | int                     @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_WITHER_SPAWN_SOUND_RADIUS, type=int)
+		"end-portal-sound-radius":                  *0 | int                     @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_END_PORTAL_SOUND_RADIUS, type=int)
+		"hanging-tick-frequency":                   *100 | int                   @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HANGING_TICK_FREQUENCY, type=int)
 		"entity-tracking-range": {
-			players:  *128 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_PLAYERS)
-			animals:  *96 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_ANIMALS)
-			monsters: *96 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_MONSTERS)
-			misc:     *96 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_MISC)
-			display:  *128 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_DISPLAY)
-			other:    *64 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_OTHER)
+			players:  *128 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_PLAYERS, type=int)
+			animals:  *96 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_ANIMALS, type=int)
+			monsters: *96 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_MONSTERS, type=int)
+			misc:     *96 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_MISC, type=int)
+			display:  *128 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_DISPLAY, type=int)
+			other:    *64 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_TRACKING_RANGE_OTHER, type=int)
 		}
-		"nerf-spawner-mobs":    *false | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_NERF_SPAWNER_MOBS)
-		"arrow-despawn-rate":   *1200 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ARROW_DESPAWN_RATE)
-		"trident-despawn-rate": *1200 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_TRIDENT_DESPAWN_RATE)
+		"nerf-spawner-mobs":    *false | bool @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_NERF_SPAWNER_MOBS, type=bool)
+		"arrow-despawn-rate":   *1200 | int   @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ARROW_DESPAWN_RATE, type=int)
+		"trident-despawn-rate": *1200 | int   @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_TRIDENT_DESPAWN_RATE, type=int)
 		"entity-activation-range": {
-			animals:           *32 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_ANIMALS)
-			monsters:          *32 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_MONSTERS)
-			raiders:           *64 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_RAIDERS)
-			misc:              *16 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_MISC)
-			water:             *16 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WATER)
-			villagers:         *32 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_VILLAGERS)
-			"flying-monsters": *32 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_FLYING_MONSTERS)
+			animals:           *32 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_ANIMALS, type=int)
+			monsters:          *32 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_MONSTERS, type=int)
+			raiders:           *64 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_RAIDERS, type=int)
+			misc:              *16 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_MISC, type=int)
+			water:             *16 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WATER, type=int)
+			villagers:         *32 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_VILLAGERS, type=int)
+			"flying-monsters": *32 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_FLYING_MONSTERS, type=int)
 			"wake-up-inactive": {
-				"animals-max-per-tick":         *4 | _    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_ANIMALS_MAX_PER_TICK)
-				"animals-every":                *1200 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_ANIMALS_EVERY)
-				"animals-for":                  *100 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_ANIMALS_FOR)
-				"monsters-max-per-tick":        *8 | _    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_MONSTERS_MAX_PER_TICK)
-				"monsters-every":               *400 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_MONSTERS_EVERY)
-				"monsters-for":                 *100 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_MONSTERS_FOR)
-				"villagers-max-per-tick":       *4 | _    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_VILLAGERS_MAX_PER_TICK)
-				"villagers-every":              *600 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_VILLAGERS_EVERY)
-				"villagers-for":                *100 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_VILLAGERS_FOR)
-				"flying-monsters-max-per-tick": *8 | _    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_FLYING_MONSTERS_MAX_PER_TICK)
-				"flying-monsters-every":        *200 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_FLYING_MONSTERS_EVERY)
-				"flying-monsters-for":          *100 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_FLYING_MONSTERS_FOR)
+				"animals-max-per-tick":         *4 | int    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_ANIMALS_MAX_PER_TICK, type=int)
+				"animals-every":                *1200 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_ANIMALS_EVERY, type=int)
+				"animals-for":                  *100 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_ANIMALS_FOR, type=int)
+				"monsters-max-per-tick":        *8 | int    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_MONSTERS_MAX_PER_TICK, type=int)
+				"monsters-every":               *400 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_MONSTERS_EVERY, type=int)
+				"monsters-for":                 *100 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_MONSTERS_FOR, type=int)
+				"villagers-max-per-tick":       *4 | int    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_VILLAGERS_MAX_PER_TICK, type=int)
+				"villagers-every":              *600 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_VILLAGERS_EVERY, type=int)
+				"villagers-for":                *100 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_VILLAGERS_FOR, type=int)
+				"flying-monsters-max-per-tick": *8 | int    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_FLYING_MONSTERS_MAX_PER_TICK, type=int)
+				"flying-monsters-every":        *200 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_FLYING_MONSTERS_EVERY, type=int)
+				"flying-monsters-for":          *100 | int  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_WAKE_UP_INACTIVE_FLYING_MONSTERS_FOR, type=int)
 			}
-			"villagers-work-immunity-after": *100 | _   @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_VILLAGERS_WORK_IMMUNITY_AFTER)
-			"villagers-work-immunity-for":   *20 | _    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_VILLAGERS_WORK_IMMUNITY_FOR)
-			"villagers-active-for-panic":    *true | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_VILLAGERS_ACTIVE_FOR_PANIC)
-			"tick-inactive-villagers":       *true | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_TICK_INACTIVE_VILLAGERS)
-			"ignore-spectators":             *false | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_IGNORE_SPECTATORS)
+			"villagers-work-immunity-after": *100 | int    @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_VILLAGERS_WORK_IMMUNITY_AFTER, type=int)
+			"villagers-work-immunity-for":   *20 | int     @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_VILLAGERS_WORK_IMMUNITY_FOR, type=int)
+			"villagers-active-for-panic":    *true | bool  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_VILLAGERS_ACTIVE_FOR_PANIC, type=bool)
+			"tick-inactive-villagers":       *true | bool  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_TICK_INACTIVE_VILLAGERS, type=bool)
+			"ignore-spectators":             *false | bool @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_ENTITY_ACTIVATION_RANGE_IGNORE_SPECTATORS, type=bool)
 		}
-		"unload-frozen-chunks": *false | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_UNLOAD_FROZEN_CHUNKS)
+		"unload-frozen-chunks": *false | bool @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_UNLOAD_FROZEN_CHUNKS, type=bool)
 		// Let seeds being randomly generated by default instead
-		"seed-village":        *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_VILLAGE)
-		"seed-desert":         *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_DESERT)
-		"seed-igloo":          *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_IGLOO)
-		"seed-jungle":         *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_JUNGLE)
-		"seed-swamp":          *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_SWAMP)
-		"seed-monument":       *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_MONUMENT)
-		"seed-shipwreck":      *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_SHIPWRECK)
-		"seed-ocean":          *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_OCEAN)
-		"seed-outpost":        *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_OUTPOST)
-		"seed-endcity":        *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_ENDCITY)
-		"seed-slime":          *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_SLIME)
-		"seed-nether":         *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_NETHER)
-		"seed-mansion":        *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_MANSION)
-		"seed-fossil":         *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_FOSSIL)
-		"seed-portal":         *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_PORTAL)
-		"seed-ancientcity":    *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_ANCIENTCITY)
-		"seed-trailruins":     *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_TRAILRUINS)
-		"seed-trialchambers":  *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_TRIALCHAMBERS)
-		"seed-buriedtreasure": *null | _      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_BURIEDTREASURE)
-		"seed-mineshaft":      *"default" | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_MINESHAFT)
-		"seed-stronghold":     *"default" | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_STRONGHOLD)
+		"seed-village":        *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_VILLAGE, type=int)
+		"seed-desert":         *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_DESERT, type=int)
+		"seed-igloo":          *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_IGLOO, type=int)
+		"seed-jungle":         *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_JUNGLE, type=int)
+		"seed-swamp":          *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_SWAMP, type=int)
+		"seed-monument":       *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_MONUMENT, type=int)
+		"seed-shipwreck":      *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_SHIPWRECK, type=int)
+		"seed-ocean":          *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_OCEAN, type=int)
+		"seed-outpost":        *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_OUTPOST, type=int)
+		"seed-endcity":        *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_ENDCITY, type=int)
+		"seed-slime":          *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_SLIME, type=int)
+		"seed-nether":         *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_NETHER, type=int)
+		"seed-mansion":        *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_MANSION, type=int)
+		"seed-fossil":         *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_FOSSIL, type=int)
+		"seed-portal":         *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_PORTAL, type=int)
+		"seed-ancientcity":    *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_ANCIENTCITY, type=int)
+		"seed-trailruins":     *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_TRAILRUINS, type=int)
+		"seed-trialchambers":  *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_TRIALCHAMBERS, type=int)
+		"seed-buriedtreasure": *null | int                  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_BURIEDTREASURE, type=int)
+		"seed-mineshaft":      *"default" | "default" | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_MINESHAFT, type=int)
+		"seed-stronghold":     *"default" | "default" | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_SEED_STRONGHOLD, type=int)
 		growth: {
-			"cactus-modifier":        *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_CACTUS_MODIFIER)
-			"cane-modifier":          *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_CANE_MODIFIER)
-			"melon-modifier":         *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_MELON_MODIFIER)
-			"mushroom-modifier":      *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_MUSHROOM_MODIFIER)
-			"pumpkin-modifier":       *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_PUMPKIN_MODIFIER)
-			"sapling-modifier":       *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_SAPLING_MODIFIER)
-			"beetroot-modifier":      *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_BEETROOT_MODIFIER)
-			"carrot-modifier":        *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_CARROT_MODIFIER)
-			"potato-modifier":        *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_POTATO_MODIFIER)
-			"torchflower-modifier":   *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_TORCHFLOWER_MODIFIER)
-			"wheat-modifier":         *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_WHEAT_MODIFIER)
-			"netherwart-modifier":    *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_NETHERWART_MODIFIER)
-			"vine-modifier":          *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_VINE_MODIFIER)
-			"cocoa-modifier":         *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_COCOA_MODIFIER)
-			"bamboo-modifier":        *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_BAMBOO_MODIFIER)
-			"sweetberry-modifier":    *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_SWEETBERRY_MODIFIER)
-			"kelp-modifier":          *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_KELP_MODIFIER)
-			"twistingvines-modifier": *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_TWISTINGVINES_MODIFIER)
-			"weepingvines-modifier":  *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_WEEPINGVINES_MODIFIER)
-			"cavevines-modifier":     *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_CAVEVINES_MODIFIER)
-			"glowberry-modifier":     *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_GLOWBERRY_MODIFIER)
-			"pitcherplant-modifier":  *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_PITCHERPLANT_MODIFIER)
+			"cactus-modifier":        *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_CACTUS_MODIFIER, type=int)
+			"cane-modifier":          *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_CANE_MODIFIER, type=int)
+			"melon-modifier":         *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_MELON_MODIFIER, type=int)
+			"mushroom-modifier":      *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_MUSHROOM_MODIFIER, type=int)
+			"pumpkin-modifier":       *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_PUMPKIN_MODIFIER, type=int)
+			"sapling-modifier":       *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_SAPLING_MODIFIER, type=int)
+			"beetroot-modifier":      *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_BEETROOT_MODIFIER, type=int)
+			"carrot-modifier":        *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_CARROT_MODIFIER, type=int)
+			"potato-modifier":        *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_POTATO_MODIFIER, type=int)
+			"torchflower-modifier":   *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_TORCHFLOWER_MODIFIER, type=int)
+			"wheat-modifier":         *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_WHEAT_MODIFIER, type=int)
+			"netherwart-modifier":    *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_NETHERWART_MODIFIER, type=int)
+			"vine-modifier":          *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_VINE_MODIFIER, type=int)
+			"cocoa-modifier":         *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_COCOA_MODIFIER, type=int)
+			"bamboo-modifier":        *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_BAMBOO_MODIFIER, type=int)
+			"sweetberry-modifier":    *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_SWEETBERRY_MODIFIER, type=int)
+			"kelp-modifier":          *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_KELP_MODIFIER, type=int)
+			"twistingvines-modifier": *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_TWISTINGVINES_MODIFIER, type=int)
+			"weepingvines-modifier":  *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_WEEPINGVINES_MODIFIER, type=int)
+			"cavevines-modifier":     *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_CAVEVINES_MODIFIER, type=int)
+			"glowberry-modifier":     *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_GLOWBERRY_MODIFIER, type=int)
+			"pitcherplant-modifier":  *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_GROWTH_PITCHERPLANT_MODIFIER, type=int)
 		}
-		"max-tnt-per-tick": *100 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MAX_TNT_PER_TICK)
+		"max-tnt-per-tick": *100 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MAX_TNT_PER_TICK, type=int)
 		"max-tick-time": {
-			tile:   *50 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MAX_TICK_TIME_TILE)
-			entity: *50 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MAX_TICK_TIME_ENTITY)
+			tile:   *50 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MAX_TICK_TIME_TILE, type=int)
+			entity: *50 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MAX_TICK_TIME_ENTITY, type=int)
 		}
 		"merge-radius": {
-			exp:  *-1.0 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MERGE_RADIUS_EXP)
-			item: *0.5 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MERGE_RADIUS_ITEM)
+			exp:  *-1.0 | float @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MERGE_RADIUS_EXP, type=number)
+			item: *0.5 | float  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_MERGE_RADIUS_ITEM, type=number)
 		}
 		hunger: {
-			"jump-walk-exhaustion":   *0.05 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_JUMP_WALK_EXHAUSTION)
-			"jump-sprint-exhaustion": *0.2 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_JUMP_SPRINT_EXHAUSTION)
-			"combat-exhaustion":      *0.1 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_COMBAT_EXHAUSTION)
-			"regen-exhaustion":       *6.0 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_REGEN_EXHAUSTION)
-			"swim-multiplier":        *0.01 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_SWIM_MULTIPLIER)
-			"sprint-multiplier":      *0.1 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_SPRINT_MULTIPLIER)
-			"other-multiplier":       *0.0 | _  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_OTHER_MULTIPLIER)
+			"jump-walk-exhaustion":   *0.05 | float @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_JUMP_WALK_EXHAUSTION, type=number)
+			"jump-sprint-exhaustion": *0.2 | float  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_JUMP_SPRINT_EXHAUSTION, type=number)
+			"combat-exhaustion":      *0.1 | float  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_COMBAT_EXHAUSTION, type=number)
+			"regen-exhaustion":       *6.0 | float  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_REGEN_EXHAUSTION, type=number)
+			"swim-multiplier":        *0.01 | float @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_SWIM_MULTIPLIER, type=number)
+			"sprint-multiplier":      *0.1 | float  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_SPRINT_MULTIPLIER, type=number)
+			"other-multiplier":       *0.0 | float  @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HUNGER_OTHER_MULTIPLIER, type=number)
 		}
 		"ticks-per": {
-			"hopper-transfer": *8 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_TICKS_PER_HOPPER_TRANSFER)
-			"hopper-check":    *1 | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_TICKS_PER_HOPPER_CHECK)
+			"hopper-transfer": *8 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_TICKS_PER_HOPPER_TRANSFER, type=int)
+			"hopper-check":    *1 | int @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_TICKS_PER_HOPPER_CHECK, type=int)
 		}
-		"hopper-amount":          *1 | _     @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HOPPER_AMOUNT)
-		"hopper-can-load-chunks": *false | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HOPPER_CAN_LOAD_CHUNKS)
-		verbose:                  *false | _ @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_VERBOSE)
+		"hopper-amount":          *1 | int      @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HOPPER_AMOUNT, type=int)
+		"hopper-can-load-chunks": *false | bool @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_HOPPER_CAN_LOAD_CHUNKS, type=bool)
+		verbose:                  *false | bool @tag(SPIGOT_WORLD_SETTINGS_DEFAULT_VERBOSE, type=bool)
 	}
 
 	stats: {
-		"disable-saving": *false | _ @tag(SPIGOT_STATS_DISABLE_SAVING)
+		"disable-saving": *false | bool @tag(SPIGOT_STATS_DISABLE_SAVING, type=bool)
 		// No mapping to any environment variable for this field since unsupported due to its complexity.
-		"forced-stats": *{} | _
+		"forced-stats": *{} | {[string]: int}
 	}
 }


### PR DESCRIPTION
The revert of #172 is necessary because of issues when injecting environment variables as string in places where other types of values are expected (e.g., booleans, ints, etc).

On top of that, PaperMC seems very bad at handling misconfigurations since specifying `'true'` (String form of a boolean) instead of `true` (a unambiguous boolean value in YAML) will lead to the property to be simply ignored without any warning.
But the fact is, even if PaperMC would detect and raise proper warnings/errors in such circunstances, it would not change the fact values inferred from environment variables are incorrect for most properties, which is unacceptable.

Therefore, it is necessary to specify the types even tho it implies more risks of drifts. However, such risk is in fact quite low is will most probably not have big consequences.

This reverts commit 1e8a7f6396cfd3e4c1ad3bbb3de4325f854e8116.