### PR TITLE
fix: minor adjustments to Helm chart

### DIFF
--- a/src/helm-chart/templates/deployment.yaml
+++ b/src/helm-chart/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
-              drop: [ "ALL" ]
+              drop: [ 'ALL' ]
           {{- with .Values.container.resources }}
           resources:
             {{- with .requests }}
@@ -39,9 +39,9 @@ spec:
               cpu: {{ .cpu }}
               memory: {{ .memory }}
             {{- end }}
-          {{-end}}
+          {{- end }}
           ports:
             - containerPort: 25565
           env:
             - name: EULA
-              value: {{ .Values.eula }}
+              value: {{ .Values.eula | squote }}

--- a/src/helm-chart/templates/papermc-service.yaml
+++ b/src/helm-chart/templates/papermc-service.yaml
@@ -8,5 +8,4 @@ spec:
     app: {{ include "papermc-server.name" . }}
   ports:
     - port: 25565
-      targetPort: 25565
       nodePort: {{ .Values.service.ports.nodePort }}

--- a/src/helm-chart/values.yaml
+++ b/src/helm-chart/values.yaml
@@ -7,11 +7,11 @@ container:
   resources:
     requests:
       ephemeralStorage: 10Gi
-      cpu: "4"
+      cpu: 4
       memory: 8Gi
     limits:
       ephemeralStorage: 10Gi
-      cpu: "4"
+      cpu: 4
       memory: 8Gi
 
 service:


### PR DESCRIPTION
* `{{-end}}` -> error
  => `{{- end }}` (spaces around matter)
* `targetPort` at Service level is useless when type is `NodePort`
* Favor single quotes in YAML files, and removing them when unecessary
* When defining an environment variable like, the value MUST be a string (e.g., `value: {{ .Values.eula }}` fails when `.Values.eula` is a boolean)
  => Always quote values with single quotes: `value: {{ .Values.eula | squote }}`