### PR TITLE
feat: add healthcheck in deployment k8s manifest

### DIFF
--- a/src/helm-chart/templates/deployment.yaml
+++ b/src/helm-chart/templates/deployment.yaml
@@ -45,3 +45,13 @@ spec:
           env:
             - name: EULA
               value: {{ .Values.eula | squote }}
+          livenessProbe:
+            exec:
+              command: ["mc-monitor", "status"]
+            periodSeconds: 5
+            timeoutSeconds: 3
+          startupProbe:
+            exec:
+              command: ["mc-monitor", "status"]
+            initialDelaySeconds: 10
+            failureThreshold: 30


### PR DESCRIPTION
Add a healthcheck in containers
This way, when the server stops for any reason (like eula not accept or any crash), the container will restart by itself