### PR TITLE
ci: explicitly require pinned hashes for MkDocs dependencies

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: 3.13
 
       - name: Install MkDocs Material
-        run: pip install --requirement docs/user-guide/requirements.txt
+        run: pip install --require-hashes --requirement docs/user-guide/requirements.txt
 
       - name: Copy License
         run: cp LICENSE.md docs/user-guide/src/license.md

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: 3.13
 
       - name: Install MkDocs Material
-        run: pip install --requirement docs/user-guide/requirements.txt
+        run: pip install --require-hashes --requirement docs/user-guide/requirements.txt
 
       - name: Copy License
         run: cp LICENSE.md docs/user-guide/src/license.md


### PR DESCRIPTION
OpenSSF Scorecard scanner is not smart enough otherwise.