### PR TITLE
build: fix pip-compile Docker wrapper on Linux systems

### DIFF
--- a/docs/user-guide/requirements/pip-compile/Dockerfile
+++ b/docs/user-guide/requirements/pip-compile/Dockerfile
@@ -4,11 +4,18 @@
 # Note: impossible to rely on v3.13.14 (missing 'cache_clear' function error)
 FROM docker.io/python:3.12.11-alpine@sha256:c610e4a94a0e8b888b4b225bfc0e6b59dee607b1e61fb63ff3926083ff617216
 
-RUN addgroup -S pip && \
-    adduser --system --disabled-password --shell /sbin/nologin pip
+ARG UID
+ARG GID
 
-ENV PATH="${PATH}:/home/pip/.local/bin"
+# BusyBox command help: https://www.busybox.net/downloads/BusyBox.html
+RUN addgroup -S -g ${GID} pip &&  \
+    adduser -S -u ${UID} -G pip pip
 
 USER pip
 
+WORKDIR /home/pip/
+
+ENV PATH="${PATH}:/home/pip/.local/bin"
+
+# Long story short: install pip-tools in the user directory to avoid permission issues.
 RUN pip install --user pip-tools

--- a/docs/user-guide/requirements/pip-compile/pip-compile.sh
+++ b/docs/user-guide/requirements/pip-compile/pip-compile.sh
@@ -23,7 +23,11 @@ case "$(uname)" in
 esac
 
 echo 'Building Docker image for pip-tools (should only take few seconds)'
-docker build --progress quiet -t docker-papermc-server/pip-tools "${SCRIPT_DIR}"
+docker build --progress quiet \
+  --build-arg "UID=$(id -u)" \
+  --build-arg "GID=$(id -g)" \
+  -t docker-papermc-server/pip-tools \
+  "${SCRIPT_DIR}"
 
 echo
 echo 'Running pip-compile:'


### PR DESCRIPTION
The permission issue is not a concern on Windows, hence why the issue was not spotted at first.

The solution consists on building the Docker image with both the UID and GID of the user running the script. This is acceptable since the Docker image is systematically built before being executed.