### PR TITLE
build: simplify `pip-compile` Docker wrapper by fixing root perm issue

### DIFF
--- a/docs/user-guide/requirements/pip-compile/Dockerfile
+++ b/docs/user-guide/requirements/pip-compile/Dockerfile
@@ -4,12 +4,9 @@
 # Note: impossible to rely on v3.13.14 (missing 'cache_clear' function error)
 FROM docker.io/python:3.12.11-alpine@sha256:c610e4a94a0e8b888b4b225bfc0e6b59dee607b1e61fb63ff3926083ff617216
 
-ARG UID
-ARG GID
-
 # BusyBox command help: https://www.busybox.net/downloads/BusyBox.html
-RUN addgroup -S -g ${GID} pip &&  \
-    adduser -S -u ${UID} -G pip pip
+RUN addgroup -S pip && \
+    adduser -S -G pip pip
 
 USER pip
 

--- a/docs/user-guide/requirements/pip-compile/pip-compile.sh
+++ b/docs/user-guide/requirements/pip-compile/pip-compile.sh
@@ -23,11 +23,10 @@ case "$(uname)" in
 esac
 
 echo 'Building Docker image for pip-tools (should only take few seconds)'
-docker build --progress quiet \
-  --build-arg "UID=$(id -u)" \
-  --build-arg "GID=$(id -g)" \
-  -t docker-papermc-server/pip-tools \
-  "${SCRIPT_DIR}"
+docker build --progress quiet -t docker-papermc-server/pip-tools "${SCRIPT_DIR}"
+
+echo 'Cleaning up old requirements.txt file'
+rm "${CURRENT_DIR}"/requirements.txt
 
 echo
 echo 'Running pip-compile:'


### PR DESCRIPTION
We just delete the `requirements.txt` file prior its regeneration. Updating an existing file causes permission issues. Creating a new one does not.

This Docker documentation section helps me spotting this: https://docs.docker.com/engine/storage/bind-mounts/#start-a-container-with-a-bind-mount.