### PR TITLE
refactor: rely on `--mount` syntax instead of the `--volume` one

### DIFF
--- a/docs/user-guide/mkdocs.sh
+++ b/docs/user-guide/mkdocs.sh
@@ -33,7 +33,7 @@ echo 'Running MkDocs:'
 # Avoid permission issues by running the container with the current user ID and group ID
 docker run --rm -p 8000:8000 --name docker-papermc-server-mkdocs \
   --user "$(id -u):$(id -g)" \
-  --volume="${ROOT_PROJECT_DIR}:/run" \
+  --mount type=bind,source="${ROOT_PROJECT_DIR}",target=/run \
   --workdir /run/docs/user-guide \
   -e MKDOCS_GIT_COMMITTERS_APIKEY="${GITHUB_TOKEN}" \
   docker-papermc-server/mkdocs \

--- a/docs/user-guide/requirements/pip-compile/pip-compile.sh
+++ b/docs/user-guide/requirements/pip-compile/pip-compile.sh
@@ -31,7 +31,7 @@ rm "${CURRENT_DIR}"/requirements.txt
 echo
 echo 'Running pip-compile:'
 docker run --rm --name docker-papermc-server-pip-compile \
-  --volume="${CURRENT_DIR}:/run" \
+  --mount type=bind,source="${CURRENT_DIR}",target=/run \
   --workdir /run \
   docker-papermc-server/pip-tools \
   pip-compile --strip-extras "$@"


### PR DESCRIPTION
You can learn more here about the difference: https://docs.docker.com/engine/storage/bind-mounts/.

In short: both syntaxes permit to achieve the exact same thing in our context, but the `--mount` is more readable, flexible and future-proof.