### PR TITLE
feat!: now read config overrides from `/config` directory

### DIFF
--- a/docs/user-guide/src/configuration-files.md
+++ b/docs/user-guide/src/configuration-files.md
@@ -16,7 +16,7 @@ They provide a more maintainable and future-proof approach to configuring advanc
 
 All configuration files must be placed in:
 
-    /opt/papermc/config/overrides
+    /config/
 
 You are free to choose any file names that suit your organization.
 
@@ -53,7 +53,7 @@ We’ll do our best to find a solution!
 
 Suppose you want to disable the End dimension in your PaperMC server.
 This would normally require setting the `settings.allow-end` property inside `bukkit.yml`.
-Now, you can create any file inside `/opt/papermc/config/overrides` and define the property under the `bukkit.global.settings` key like this:
+Now, you can create any file inside `/config/` and define the property under the `bukkit.global.settings` key like this:
 
 ```yaml
 bukkit:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -118,13 +118,14 @@ RUN apk add --no-cache gettext libudev-zero
 COPY --chmod=770 runtime/ ./
 
 # Adjust permissions.
+# Set default ones for mount points knowing that they can be overridden at runtime (e.g., Kubernetes's security context "fsGroup").
 RUN chmod 770 /opt/papermc && \
-    chmod 550 /opt/papermc/start.sh
-
-# Prepare data directories by setting proper default permissions.
-# Avoid "access denied" errors when the server attempts to create or modify files.
-# See https://stackoverflow.com/a/64034092/10165346
-RUN mkdir --parent /data/worlds && \
+    chmod 550 /opt/papermc/start.sh && \
+    # Overrides config files
+    mkdir /config && \
+    chown daemon /config && \
+    # Data directories
+    mkdir --parent /data/worlds && \
     chown daemon /data/worlds
 
 # mc-monitor setup for health-checks.

--- a/src/runtime/start.sh
+++ b/src/runtime/start.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)
 ## Directories
 ROOT_DIR="${SCRIPT_DIR}"
 CONFIG_DIR="${SCRIPT_DIR}/config"
-OVERRIDES_CONFIG_DIR="${CONFIG_DIR}/overrides"
+OVERRIDES_CONFIG_DIR="/config"
 CUE_DIR="${CONFIG_DIR}/cue"
 
 IS_SERVER_RESTART=false


### PR DESCRIPTION
BREAKING-CHANGE: overrides config files are no longer taken into account when located under the `/opt/papermc/config/overrides` directory.